### PR TITLE
Simple dev container definition

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -8,7 +8,10 @@ RUN rm -f /etc/localtime /etc/timezone
 # Install packages from distribution repos
 RUN <<EOF
 apt-get update && apt-get install --assume-yes --no-install-recommends \
-  git
+  git \
+  vim \
+  less \
+  make
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,14 @@
+# Use the same base image as used to build the brics_jupyterhub container image
+# See https://github.com/isambard-sc/brics_jupyterhub_envs/blob/main/brics_jupyterhub/Containerfile
+FROM quay.io/jupyterhub/jupyterhub:latest
+
+# Remove timezone information, if present (default to UTC)
+RUN rm -f /etc/localtime /etc/timezone
+
+# Install packages from distribution repos
+RUN <<EOF
+apt-get update && apt-get install --assume-yes --no-install-recommends \
+  git
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOF

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,34 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-	"name": "Ubuntu",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:jammy",
-	"features": {
-		"ghcr.io/devcontainers/features/python:1": {
-			"installTools": true,
-			"version": "latest"
-		}
-	},
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
-
-	// Necessary to workaround issue with using podman as Docker CLI provider
-	// See: https://code.visualstudio.com/remote/advancedcontainers/docker-options#_podman
-	"containerEnv": {
-		"HOME": "/home/vscode"
-	}
+  "name": "bricsauthenticator",
+  "build": { 
+    "dockerfile": "Containerfile"
+  },
+  "remoteUser": "root",
+  "containerUser": "root",
+  "forwardPorts": [8000],
+  "portsAttributes": {
+    "8000": {
+      "label": "JupyterHub",
+      "onAutoForward": "notify",
+      "requireLocalPort": true
+    }
+  },
+  "postCreateCommand": "python3 -m pip install --no-cache-dir --root-user-action=ignore --editable '${containerWorkspaceFolder}[dev]'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"installTools": true,
+			"version": "latest"
+		}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+	// Necessary to workaround issue with using podman as Docker CLI provider
+	// See: https://code.visualstudio.com/remote/advancedcontainers/docker-options#_podman
+	"containerEnv": {
+		"HOME": "/home/vscode"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,5 +13,8 @@
       "requireLocalPort": true
     }
   },
-  "postCreateCommand": "python3 -m pip install --no-cache-dir --root-user-action=ignore --editable '${containerWorkspaceFolder}[dev]'"
+  "postCreateCommand": "python3 -m pip install --no-cache-dir --root-user-action=ignore --editable '${containerWorkspaceFolder}[dev]'",
+  
+  // Disable labelling to avoid access issues with bind-mounting workspace folder for hosts using SELinux
+  "securityOpt": ["label=disable"]
 }

--- a/.github/workflows/devcontainer_build_test.yml
+++ b/.github/workflows/devcontainer_build_test.yml
@@ -1,0 +1,31 @@
+name: "Dev Container: build and run tests"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build_and_test:
+    
+    permissions:
+      contents: read
+
+    name: "Dev Container: build and run tests"
+    runs-on: ubuntu-latest
+    
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Build and run tests
+      uses: devcontainers/ci@v0.3
+      with:
+        configFile: ./.devcontainer/devcontainer.json
+        push: never
+        runCmd: make test

--- a/.github/workflows/devcontainer_build_test.yml
+++ b/.github/workflows/devcontainer_build_test.yml
@@ -22,6 +22,9 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+        fetch-depth: 0
 
     - name: Build and run tests
       uses: devcontainers/ci@v0.3

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ conda env create -f environment-dev.yml
 A [dev container][containers.dev] [metadata JSON file][metadata-ref-containers.dev] ([devcontainer.json](./.devcontainer/devcontainer.json)) is provided that defines a `bricsauthenticator` development environment with the following characteristics
 
 * [Official JupyterHub Docker image][jupyterhub-docker-quay.io] as base image
-* Development tooling installed in base image via accompanying `Containerfile`
+* Development tooling installed in base image via accompanying [Containerfile](./.devcontainer/Containerfile)
 * Run as root inside container
 * Forward port 8000 (the default listening port for JupyterHub's public proxy)
 * Editable pip install of source code in local workspace

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The dev environment can be launched using [dev-container-compatible tooling][too
 Within the container image JupyterHub is preinstalled as a `pip` package. On container creation, an editable `pip` install of `bricsauthenticator` with development dependencies is performed (from the local copy of the source code bind-mounted into the container). This allows development and testing of the source code within the running dev container.
 
 [containers.dev]: https://containers.dev/
-[metadata-ref-containers.dev]: https://containers.dev/implementors/json_reference/]
+[metadata-ref-containers.dev]: https://containers.dev/implementors/json_reference/
 [jupyterhub-docker-quay.io]: https://quay.io/repository/jupyterhub/jupyterhub
 [tooling-containers.dev]: https://containers.dev/supporting
 [dev-containers-vscode-ext]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers

--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ conda env create -f environment-dev.yml
 > [!NOTE]
 > This must be run from the root of the repository, since a relative path is used to install the `bricsauthenticator` package.
 
+## Dev container
+
+A [dev container][containers.dev] [metadata JSON file][metadata-ref-containers.dev] is provided that defines a `bricsauthenticator` development environment with the following characteristics
+
+* [Official JupyterHub Docker image][jupyterhub-docker-quay.io] as base image
+* Development tooling installed in base image via accompanying `Containerfile`
+* Run as root inside container
+* Forward port 8000 (the default listening port for JupyterHub's public proxy)
+* Editable pip install of source code in local workspace
+
+The dev environment can be launched using [dev-container-compatible tooling][tooling-containers.dev], e.g. VSCode (with [Dev Containers extension][dev-containers-vscode-ext]) and [GitHub Codespaces][dev-containers-github-codespaces-docs].
+
+Within the container image JupyterHub is preinstalled as a `pip` package. On container creation, an editable `pip` install of `bricsauthenticator` with development dependencies is performed (from the local copy of the source code bind-mounted into the container). This allows development and testing of the source code within the running dev container.
+
+[containers.dev]: https://containers.dev/
+[metadata-ref-containers.dev]: https://containers.dev/implementors/json_reference/]
+[jupyterhub-docker-quay.io]: https://quay.io/repository/jupyterhub/jupyterhub
+[tooling-containers.dev]: https://containers.dev/supporting
+[dev-containers-vscode-ext]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+[dev-containers-github-codespaces-docs]: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers
+
 ## Usage
 
 <!-- TODO -->
@@ -110,7 +131,7 @@ conda env create -f environment-dev.yml
 
 ## Development
 
-It is recommended to develop in a virtual environment, with [an editable install of the package, and development tools installed](#install-with-development-dependencies).
+It is recommended to develop in a virtual environment, with [an editable install of the package, and development tools installed](#install-with-development-dependencies). The [dev container](#dev-container) automatically performs an editable development install of the package on container creation.
 
 ### Documentation
   

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ conda env create -f environment-dev.yml
 
 ## Dev container
 
-A [dev container][containers.dev] [metadata JSON file][metadata-ref-containers.dev] is provided that defines a `bricsauthenticator` development environment with the following characteristics
+A [dev container][containers.dev] [metadata JSON file][metadata-ref-containers.dev] ([devcontainer.json](./.devcontainer/devcontainer.json)) is provided that defines a `bricsauthenticator` development environment with the following characteristics
 
 * [Official JupyterHub Docker image][jupyterhub-docker-quay.io] as base image
 * Development tooling installed in base image via accompanying `Containerfile`


### PR DESCRIPTION
[Dev container metadata JSON file](https://containers.dev/implementors/json_reference/) that defines a `bricsauthenticator` development environment with the following characteristics

* [Official JupyterHub Docker image](https://quay.io/repository/jupyterhub/jupyterhub) as base image (same as <https://github.com/isambard-sc/brics_jupyterhub_envs>)
* Development tooling installed in base image via accompanying Containerfile
* Run as root inside container
* Forward port 8000 (default port for JupyterHub)
* Editable pip install of source code in local workspace

The dev environment can be launched using [dev-container-compatible tooling](https://containers.dev/supporting), e.g. VSCode (with [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)) and [GitHub Codespaces](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers). 

This PR also added a GitHub Actions workflow that builds the dev container and runs the package tests inside the container (using the [devcontainers/ci action](https://github.com/devcontainers/ci)).