### PR TITLE
Update `bricsauthenticator`to make use of per-project-resource data in new JWT format

### DIFF
--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -31,6 +31,10 @@ class BricsLoginHandler(BaseHandler):
         signing_key = self._fetch_signing_key(jwks_uri, token)
         decoded_token = self._decode_jwt(token, signing_key, signing_algos)
 
+        self.log.debug(
+            "Decoded JWT Token:\n" + "\n".join(f"{key}: {value}" for key, value in decoded_token.items())
+        )
+
         projects = self._normalize_projects(decoded_token)
 
         username = decoded_token.get("short_name")
@@ -52,6 +56,7 @@ class BricsLoginHandler(BaseHandler):
         if not token:
             raise web.HTTPError(401, "Missing X-Auth-Id-Token header")
         self.log.debug(f"Raw JWT Token: {token}")
+        self.log.debug(f"Raw JWT Size: {len(token.encode('ascii'))} bytes")
         return token
 
     async def _fetch_oidc_config(self) -> dict:

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -25,7 +25,7 @@ class BricsLoginHandler(BaseHandler):
 
     async def get(self):
 
-        self.log.debug("Estimated request header size: {:d} bytes", sum(len((name + ":" + value).encode("ascii")) for name, value in self.request.headers.get_all()))
+        self.log.debug("Estimated request header size: %d bytes", sum(len((name + ":" + value).encode("ascii")) for name, value in self.request.headers.get_all()))
 
         token = self._extract_token()
 

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -25,7 +25,10 @@ class BricsLoginHandler(BaseHandler):
 
     async def get(self):
 
-        self.log.debug("Estimated request header size: %d bytes", sum(len((name + ":" + value).encode("ascii")) for name, value in self.request.headers.get_all()))
+        self.log.debug(
+            "Estimated request header size: %d bytes",
+            sum(len((name + ":" + value).encode("ascii")) for name, value in self.request.headers.get_all()),
+        )
 
         token = self._extract_token()
 
@@ -34,9 +37,7 @@ class BricsLoginHandler(BaseHandler):
         signing_key = self._fetch_signing_key(jwks_uri, token)
         decoded_token = self._decode_jwt(token, signing_key, signing_algos)
 
-        self.log.debug(
-            "Decoded JWT Token:\n" + "\n".join(f"{key}: {value}" for key, value in decoded_token.items())
-        )
+        self.log.debug("Decoded JWT Token:\n" + "\n".join(f"{key}: {value}" for key, value in decoded_token.items()))
 
         projects = self._normalize_projects(decoded_token)
 

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -24,6 +24,9 @@ class BricsLoginHandler(BaseHandler):
         return jwt.PyJWKClient(jwks_uri, headers=headers)
 
     async def get(self):
+
+        self.log.debug("Estimated request header size: {:d} bytes", sum(len((name + ":" + value).encode("ascii")) for name, value in self.request.headers.get_all()))
+
         token = self._extract_token()
 
         oidc_config = await self._fetch_oidc_config()

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -110,7 +110,7 @@ class BricsLoginHandler(BaseHandler):
                 f"Invalid projects format after decoding (expected dict, got {type(projects)}), returning empty"
             )
             return {}
-
+        
         return projects
 
     def _auth_state_from_projects(self, projects: dict, platform: str) -> dict:

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -110,7 +110,7 @@ class BricsLoginHandler(BaseHandler):
                 f"Invalid projects format after decoding (expected dict, got {type(projects)}), returning empty"
             )
             return {}
-        
+
         return projects
 
     def _auth_state_from_projects(self, projects: dict, platform: str) -> dict:
@@ -148,7 +148,7 @@ class BricsLoginHandler(BaseHandler):
 
         The returned auth_state is a transformed version of this claim which
         contains data only for projects where there is at least one resource
-        with a name which matches `platform`, e.g. for 
+        with a name which matches `platform`, e.g. for
         `platform` == portal.example.notebooks.shared the result is
 
         {
@@ -169,6 +169,7 @@ class BricsLoginHandler(BaseHandler):
                     auth_state[project_id] = {"name": project_data["name"], "username": resource["username"]}
                     break
         return auth_state
+
 
 class BricsAuthenticator(Authenticator):
 

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -6,7 +6,7 @@ from typing import Callable
 
 import batchspawner
 from tornado import web
-from traitlets import Dict, List, Unicode, default
+from traitlets import Dict, Unicode, default
 
 from bricsauthenticator.spawner_options_form import interpret_form_data, make_options_form
 

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -73,7 +73,7 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         def spawner_options_form(spawner):
             if not self.make_options_form_fn:
                 raise ValueError("make_options_form_fn is not provided")
-            return self.make_options_form_fn(project_list=list(spawner.brics_projects.keys()))
+            return self.make_options_form_fn(projects=spawner.brics_projects)
 
         return spawner_options_form
 

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -17,10 +17,10 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
     """
 
     brics_projects = Dict(
-        value_trait=List(trait=Unicode()),
+        value_trait=Dict(value_trait=Unicode(), key_trait=Unicode()),
         key_trait=Unicode(),
         help="""
-        Dictionary mapping BriCS project names to lists of associated BriCS infrastructures.
+        Dictionary mapping BriCS project names to dict of associated BriCS resources.
         
         Should be set by Authenticator via Spawner.auth_state_hook()
         """,
@@ -51,7 +51,7 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
             spawner.log.debug("Entering auth_state_hook")
             if auth_state:
                 spawner.log.debug(f"Acquired auth_state: {str(auth_state)}")
-                spawner.brics_projects = {k.split(".")[0]: v for k, v in auth_state.items()}
+                spawner.brics_projects = auth_state
             else:
                 spawner.log.debug("No auth_state acquired")
                 spawner.brics_projects = {}
@@ -103,12 +103,12 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
     @property
     def brics_project_user_name(self) -> str:
         """
-        Get the BriCS project user name of the form <USER>.<PROJECT>
+        Get the BriCS project user name based on the project selected in the spawner options form
 
         :return: BriCS project user name
         """
         self.log.debug("Entering BricsSlurmSpawner.brics_project_user_name()")
-        return self.user.name + "." + self.brics_project_name
+        return self.brics_projects[self.user_options["brics_project"]]["username"]
 
     @property
     def brics_project_name(self) -> str:
@@ -132,7 +132,7 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         Dynamic default value for req_homedir trait
         """
         self.log.debug("Entering BricsSlurmSpawner._req_homedir_default()")
-        return f"/home/{self.brics_project_name}/{self.brics_project_user_name}"
+        return f"/home/{self.brics_project_name.partition('.')[0]}/{self.brics_project_user_name}"
 
     def user_env(self, env):
         """

--- a/src/bricsauthenticator/spawner_options_form.py
+++ b/src/bricsauthenticator/spawner_options_form.py
@@ -7,7 +7,7 @@ import shlex
 from datetime import datetime
 
 
-def make_options_form(project_list: list[str]) -> str:
+def make_options_form(projects: dict[str, dict]) -> str:
     """
     Return a HTML options form for user to configure spawned session
 
@@ -15,8 +15,9 @@ def make_options_form(project_list: list[str]) -> str:
     surrounding `<form>` element and submit button are not included, as are
     added when this function is called by JupyterHub.
 
-    :param project_list: list of selectable projects, typically provided by
-      :class:`Spawner` instance
+    :param projects: dict containing information about selectable projects, 
+      where keys are project identifiers and the value dict contains the 
+      human-readable project name, typically provided by :class:`Spawner` instance
     :return: HTML form with user-selectable JupyterHub spawner options
     """
 
@@ -24,12 +25,11 @@ def make_options_form(project_list: list[str]) -> str:
     # This causes form controls to be horizontally aligned
     label_style = "display:inline-block;width:16em;text-align:left"
 
-    # TODO Restrict list of selectable projects to those with access to Jupyter resources
     # Handle empty project list
-    if not project_list:
+    if not projects:
         project_options = ['<option value="" disabled>No projects available</option>']
     else:
-        project_options = [f'<option value="{project}">{project}</option>' for project in project_list]
+        project_options = [f'<option value="{project_id}">{project_id}: {project_data["name"]}</option>' for project_id, project_data in projects.items()]
 
     project_select = f'<label style="{label_style}" for="brics_project_select">Choose a project:</label>' + "\n".join(
         ['<select name="brics_project" id="brics_project_select">'] + project_options + ["</select>"]

--- a/src/bricsauthenticator/spawner_options_form.py
+++ b/src/bricsauthenticator/spawner_options_form.py
@@ -15,8 +15,8 @@ def make_options_form(projects: dict[str, dict]) -> str:
     surrounding `<form>` element and submit button are not included, as are
     added when this function is called by JupyterHub.
 
-    :param projects: dict containing information about selectable projects, 
-      where keys are project identifiers and the value dict contains the 
+    :param projects: dict containing information about selectable projects,
+      where keys are project identifiers and the value dict contains the
       human-readable project name, typically provided by :class:`Spawner` instance
     :return: HTML form with user-selectable JupyterHub spawner options
     """
@@ -29,7 +29,10 @@ def make_options_form(projects: dict[str, dict]) -> str:
     if not projects:
         project_options = ['<option value="" disabled>No projects available</option>']
     else:
-        project_options = [f'<option value="{project_id}">{project_id}: {project_data["name"]}</option>' for project_id, project_data in projects.items()]
+        project_options = [
+            f'<option value="{project_id}">{project_id}: {project_data["name"]}</option>'
+            for project_id, project_data in projects.items()
+        ]
 
     project_select = f'<label style="{label_style}" for="brics_project_select">Choose a project:</label>' + "\n".join(
         ['<select name="brics_project" id="brics_project_select">'] + project_options + ["</select>"]

--- a/src/bricsauthenticator/spawner_options_form.py
+++ b/src/bricsauthenticator/spawner_options_form.py
@@ -115,7 +115,7 @@ def validate_form_data(form_data, valid_projects):
         raise ValueError("unknown form data keys")
 
     # Validate brics_project
-    brics_project_regex = r"^[a-z][a-z0-9\-_]+$"
+    brics_project_regex = r"^[a-z][a-z0-9\-_]*\.[a-z][a-z0-9\-_]*$"
     brics_project = str(form_data["brics_project"][0])
     if not re.fullmatch(brics_project_regex, brics_project):
         raise ValueError("brics_project not valid")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,6 +5,7 @@ import jwt
 import pytest
 from tornado.httputil import HTTPServerRequest
 from tornado.web import Application, HTTPError
+from tornado.httputil import HTTPHeaders
 
 from bricsauthenticator.auth import BricsAuthenticator, BricsLoginHandler
 
@@ -19,9 +20,10 @@ def handler():
         "log_function": MagicMock(),  # Mock the application-level logger
     }
 
-    # Mock request with a connection attribute
+    # Mock request with a connection attribute and empty headers
     request = MagicMock(spec=HTTPServerRequest)
     request.connection = MagicMock()  # Add the 'connection' attribute
+    request.headers = HTTPHeaders({})
 
     # Initialize BricsLoginHandler with the mocked application, request, and required arguments
     handler_instance = BricsLoginHandler(
@@ -33,7 +35,7 @@ def handler():
 
 
 def test_extract_token_missing_header(handler):
-    handler.request.headers = {}
+    handler.request.headers = HTTPHeaders({})
     with pytest.raises(HTTPError) as exc_info:
         handler._extract_token()
     assert exc_info.value.status_code == 401
@@ -41,7 +43,7 @@ def test_extract_token_missing_header(handler):
 
 
 def test_extract_token_success(handler):
-    handler.request.headers = {"X-Auth-Id-Token": "fake_token"}
+    handler.request.headers = HTTPHeaders({"X-Auth-Id-Token": "fake_token"})
     token = handler._extract_token()
     assert token == "fake_token"
 
@@ -225,6 +227,7 @@ async def test_get():
     # Mock request with a connection attribute
     request = MagicMock(spec=HTTPServerRequest)
     request.connection = MagicMock()  # Add the 'connection' attribute
+    request.headers = HTTPHeaders({"X-Auth-Id-Token": "fake_token"})
 
     # Create an instance of the handler
     handler = BricsLoginHandler(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -119,6 +119,49 @@ def test_normalize_projects_none(handler):
     result = handler._normalize_projects(decoded_token)
     assert result == {}
 
+@pytest.mark.parametrize(
+        "platform,normalized_projects,expected_result",
+        [
+            pytest.param(
+                "portal.example.clusters.shared",
+                {"project1": {"name": "Project 1", "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}]}},
+                {},
+                id = "1 project, 0 matching platform"
+            ),
+            pytest.param(
+                "portal.example.notebooks.shared",
+                {"project1": {"name": "Project 1", "resources": [{"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},{"name": "portal.example.other.shared", "username": "test_user.project1"}]}},
+                {"project1": {"name": "Project 1", "username": "test_notebook_user.project1"}},
+                id = "1 project, 1 matching platform"
+            ),
+            pytest.param(
+                "portal.example.clusters.shared",
+                {"project1": {"name": "Project 1", "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}]},
+                 "project2": {"name": "Project 2", "resources": [{"name": "portal.example.other.shared", "username": "test_user.project2"}]}},
+                {},
+                id = "2 project, 0 matching platform"
+            ),
+            pytest.param(
+                "portal.example.notebooks.shared",
+                {"project1": {"name": "Project 1", "resources": [{"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},{"name": "portal.example.cluster.shared", "username": "test_cluster_user.project1"}]},
+                 "project2": {"name": "Project 2", "resources": [{"name": "portal.example.other.shared", "username": "test_user.project2"}]}},
+                {"project1": {"name": "Project 1", "username": "test_notebook_user.project1"}},
+                id = "2 project, 1 matching platform"
+            ),
+            pytest.param(
+                "portal.example.notebooks.shared",
+                {"project1": {"name": "Project 1", "resources": [{"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},{"name": "portal.example.cluster.shared", "username": "test_cluster_user.project1"}]},
+                 "project2": {"name": "Project 2", "resources": [{"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}]}},
+                {"project1": {"name": "Project 1", "username": "test_notebook_user.project1"},
+                 "project2": {"name": "Project 2", "username": "test_notebook_user.project2"},
+                },
+                id = "2 project, 2 matching platform"
+            ),
+        ]
+)
+def test_auth_state_from_projects(handler, platform: str, normalized_projects: dict, expected_result: dict):
+    result = handler._auth_state_from_projects(projects=normalized_projects, platform=platform)
+    assert result == expected_result
 
 @pytest.mark.asyncio
 async def test_get():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -129,7 +129,7 @@ def test_normalize_projects_none(handler):
         pytest.param(
             "portal.example.clusters.shared",
             {
-                "project1": {
+                "project1.portal": {
                     "name": "Project 1",
                     "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
                 }
@@ -140,7 +140,7 @@ def test_normalize_projects_none(handler):
         pytest.param(
             "portal.example.notebooks.shared",
             {
-                "project1": {
+                "project1.portal": {
                     "name": "Project 1",
                     "resources": [
                         {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
@@ -148,17 +148,17 @@ def test_normalize_projects_none(handler):
                     ],
                 }
             },
-            {"project1": {"name": "Project 1", "username": "test_notebook_user.project1"}},
+            {"project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"}},
             id="1 project, 1 matching platform",
         ),
         pytest.param(
             "portal.example.clusters.shared",
             {
-                "project1": {
+                "project1.portal": {
                     "name": "Project 1",
                     "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
                 },
-                "project2": {
+                "project2.portal": {
                     "name": "Project 2",
                     "resources": [{"name": "portal.example.other.shared", "username": "test_user.project2"}],
                 },
@@ -169,32 +169,32 @@ def test_normalize_projects_none(handler):
         pytest.param(
             "portal.example.notebooks.shared",
             {
-                "project1": {
+                "project1.portal": {
                     "name": "Project 1",
                     "resources": [
                         {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
                         {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
                     ],
                 },
-                "project2": {
+                "project2.portal": {
                     "name": "Project 2",
                     "resources": [{"name": "portal.example.other.shared", "username": "test_user.project2"}],
                 },
             },
-            {"project1": {"name": "Project 1", "username": "test_notebook_user.project1"}},
+            {"project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"}},
             id="2 project, 1 matching platform",
         ),
         pytest.param(
             "portal.example.notebooks.shared",
             {
-                "project1": {
+                "project1.portal": {
                     "name": "Project 1",
                     "resources": [
                         {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
                         {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
                     ],
                 },
-                "project2": {
+                "project2.portal": {
                     "name": "Project 2",
                     "resources": [
                         {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}
@@ -202,8 +202,8 @@ def test_normalize_projects_none(handler):
                 },
             },
             {
-                "project1": {"name": "Project 1", "username": "test_notebook_user.project1"},
-                "project2": {"name": "Project 2", "username": "test_notebook_user.project2"},
+                "project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"},
+                "project2.portal": {"name": "Project 2", "username": "test_notebook_user.project2"},
             },
             id="2 project, 2 matching platform",
         ),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,7 +24,7 @@ def handler():
     request.connection = MagicMock()  # Add the 'connection' attribute
 
     # Initialize BricsLoginHandler with the mocked application, request, and required arguments
-    handler_instance = BricsLoginHandler(application, request, oidc_server="https://example.com")
+    handler_instance = BricsLoginHandler(application, request, platform="portal.cluster.example.shared", oidc_server="https://example.com")
     handler_instance.http_client = AsyncMock()
     handler_instance.jwks_client_factory = MagicMock()
     return handler_instance

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,9 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
 import pytest
-from tornado.httputil import HTTPServerRequest
+from tornado.httputil import HTTPHeaders, HTTPServerRequest
 from tornado.web import Application, HTTPError
-from tornado.httputil import HTTPHeaders
 
 from bricsauthenticator.auth import BricsAuthenticator, BricsLoginHandler
 

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -7,7 +7,10 @@ def test_auth_state_hook_default():
     spawner = BricsSlurmSpawner()
     auth_state_hook = spawner.auth_state_hook
 
-    mock_auth_state = {"project1": ["infra1", "infra2"]}
+    mock_auth_state = {
+        "project1": {"name": "Project 1", "username": "test_notebook_user.project1"},
+        "project2": {"name": "Project 2", "username": "test_notebook_user.project2"},
+    }
     spawner.brics_projects = {}
     auth_state_hook(spawner, mock_auth_state)
 
@@ -27,24 +30,25 @@ def test_options_form_default(mocker):
 
 
 def test_options_from_form_default(mocker):
-    mock_interpret_form_data = mocker.MagicMock(return_value={"brics_project": "project1"})
+    mock_interpret_form_data = mocker.MagicMock(return_value={"brics_project": "project1.portal"})
     spawner = BricsSlurmSpawner(interpret_form_data_fn=mock_interpret_form_data)
-    form_data = {"brics_project": ["project1"]}
+    spawner.brics_projects = {"project1.portal": {"name": "Project 1", "username": "test_user"}}
+    form_data = {"brics_project": ["project1.portal"]}
 
     options_callable = spawner.options_from_form
     user_options = options_callable(form_data, spawner)
-    assert user_options == {"brics_project": "project1"}
-    mock_interpret_form_data.assert_called_once_with(form_data, set())
+    assert user_options == {"brics_project": "project1.portal"}
+    mock_interpret_form_data.assert_called_once_with(form_data, {"project1.portal"})
 
 
 def test_brics_project_properties():
     spawner = BricsSlurmSpawner()
+    spawner.brics_projects = {"project1.portal": {"name": "Project 1", "username": "test_user.project1"}}
     spawner.user = MagicMock()
-    spawner.user.name = "testuser"
-    spawner.user_options = {"brics_project": "project1"}
+    spawner.user_options = {"brics_project": "project1.portal"}
 
-    assert spawner.brics_project_user_name == "testuser.project1"
-    assert spawner.brics_project_name == "project1"
+    assert spawner.brics_project_user_name == "test_user.project1"
+    assert spawner.brics_project_name == "project1.portal"
 
 
 def test_user_env():
@@ -63,15 +67,14 @@ def test_req_username_default():
     Test the _req_username_default method to ensure it constructs the username correctly.
     """
     spawner = BricsSlurmSpawner()
-    spawner.user = MagicMock()
-    spawner.user.name = "testuser"
-    spawner.user_options = {"brics_project": "project1"}
+    spawner.brics_projects = {"project1.portal": {"name": "Project 1", "username": "test_user.project1"}}
+    spawner.user_options = {"brics_project": "project1.portal"}
 
     # Call the method (which is a traitlets dynamic default value for the req_username trait)
     result = spawner.req_username
 
     # Assert the expected result
-    assert result == "testuser.project1"
+    assert result == "test_user.project1"
 
 
 def test_req_homedir_default():
@@ -79,12 +82,11 @@ def test_req_homedir_default():
     Test the _req_homedir_default method to ensure it constructs the home directory path correctly.
     """
     spawner = BricsSlurmSpawner()
-    spawner.user = MagicMock()
-    spawner.user.name = "testuser"
-    spawner.user_options = {"brics_project": "project1"}
+    spawner.brics_projects = {"project1.portal": {"name": "Project 1", "username": "test_user.project1"}}
+    spawner.user_options = {"brics_project": "project1.portal"}
 
     # Call the method (which is a traitlets dynamic default value for the req_username trait)
     result = spawner.req_homedir
 
     # Assert the expected result
-    assert result == "/home/project1/testuser.project1"
+    assert result == "/home/project1/test_user.project1"

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -8,8 +8,8 @@ def test_auth_state_hook_default():
     auth_state_hook = spawner.auth_state_hook
 
     mock_auth_state = {
-        "project1": {"name": "Project 1", "username": "test_notebook_user.project1"},
-        "project2": {"name": "Project 2", "username": "test_notebook_user.project2"},
+        "project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"},
+        "project2.portal": {"name": "Project 2", "username": "test_notebook_user.project2"},
     }
     spawner.brics_projects = {}
     auth_state_hook(spawner, mock_auth_state)

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -26,7 +26,7 @@ def test_options_form_default(mocker):
 
     form_callable = spawner.options_form
     assert form_callable(spawner) == "<form>mock_form</form>"
-    mock_make_options_form.assert_called_once_with(project_list=[])
+    mock_make_options_form.assert_called_once_with(projects={})
 
 
 def test_options_from_form_default(mocker):

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -85,7 +85,7 @@ def test_req_homedir_default():
     spawner.brics_projects = {"project1.portal": {"name": "Project 1", "username": "test_user.project1"}}
     spawner.user_options = {"brics_project": "project1.portal"}
 
-    # Call the method (which is a traitlets dynamic default value for the req_username trait)
+    # Call the method (which is a traitlets dynamic default value for the req_homedir trait)
     result = spawner.req_homedir
 
     # Assert the expected result

--- a/tests/test_spawner_options_form.py
+++ b/tests/test_spawner_options_form.py
@@ -30,7 +30,12 @@ class TestInterpretFormData:
 
     @pytest.fixture
     def valid_projects(self):
-        return {"valid_project.a_portal", "valid-project.a-portal", "validproject1.portal1", "another_project.anotherportal"}
+        return {
+            "valid_project.a_portal",
+            "valid-project.a-portal",
+            "validproject1.portal1",
+            "another_project.anotherportal",
+        }
 
     @pytest.mark.parametrize(
         "form_data",
@@ -74,12 +79,9 @@ class TestInterpretFormData:
         assert result["partition"] == form_data["partition"][0]
         assert result["reservation"] == form_data["reservation"][0]
 
-    @pytest.mark.parametrize("project",
-        [
-            "unknown_project.unknown_portal",
-            "unknown-project.unknown-portal",
-            "unknownproject1.unknownportal1"
-        ]
+    @pytest.mark.parametrize(
+        "project",
+        ["unknown_project.unknown_portal", "unknown-project.unknown-portal", "unknownproject1.unknownportal1"],
     )
     def test_invalid_brics_project(self, valid_projects, project):
         form_data = {
@@ -259,6 +261,7 @@ class TestInterpretFormData:
 
         with pytest.raises(ValueError):
             interpret_form_data(form_data, valid_projects)
+
 
 class TestMakeOptionsForm:
 

--- a/tests/test_spawner_options_form.py
+++ b/tests/test_spawner_options_form.py
@@ -3,11 +3,6 @@ import pytest
 from bricsauthenticator.spawner_options_form import defuse, interpret_form_data, make_options_form
 
 
-class TestMakeOptionsForm:
-    # TODO Implement tests for make_options_form
-    pass
-
-
 class TestDefuse:
     @pytest.mark.parametrize(
         "input_to_defuse, defused_output",
@@ -250,26 +245,32 @@ class TestInterpretFormData:
         with pytest.raises(ValueError):
             interpret_form_data(form_data, valid_projects)
 
+class TestMakeOptionsForm:
+
     def test_make_options_form_basic(self):
         """
         Test the make_options_form function with a basic project list.
         """
-        project_list = ["project1", "project2", "project3"]
-        html_output = make_options_form(project_list)
+        projects = {
+            "project1.portal": {"name": "Important project 1", "username": "vip.project1"},
+            "project2.portal": {"name": "A Project 2", "username": "a_user.project2"},
+            "project3.portal": {"name": "The Project 3", "username": "the_user.project3"},
+        }
+        html_output = make_options_form(projects)
 
-        for project in project_list:
-            assert f'<option value="{project}">{project}</option>' in html_output
+        for project_id, project_data in projects.items():
+            assert f'<option value="{project_id}">{project_id}: {project_data["name"]}</option>' in html_output
 
         assert '<select name="brics_project" id="brics_project_select">' in html_output
         assert '<select name="runtime" id="runtime_select">' in html_output
         assert '<select name="ngpus" id="ngpus_select">' in html_output
 
-    def test_make_options_form_empty_project_list(self):
+    def test_make_options_form_empty_projects(self):
         """
-        Test the make_options_form function with an empty project list.
+        Test the make_options_form function with an empty projects dict
         """
-        project_list = []
-        html_output = make_options_form(project_list)
+        project_list = {}
+        html_output = make_options_form({})
 
         # Check for the placeholder option
         assert '<option value="" disabled>No projects available</option>' in html_output
@@ -281,8 +282,12 @@ class TestInterpretFormData:
         """
         Test the make_options_form function with project names containing special characters.
         """
-        project_list = ["proj&1", "proj<2", "proj>3"]
-        html_output = make_options_form(project_list)
+        projects = {
+            "proj&1": {"name": "Special char project 1", "username": "special_char_user1"},
+            "proj<2": {"name": "Special char project 2", "username": "special_char_user2"},
+            "proj>3": {"name": "Special char project 3", "username": "special_char_user3"},
+        }
+        html_output = make_options_form(projects)
 
-        for project in project_list:
-            assert f'<option value="{project}">{project}</option>' in html_output
+        for project_id, project_data in projects.items():
+            assert f'<option value="{project_id}">{project_id}: {project_data["name"]}</option>' in html_output


### PR DESCRIPTION
Follow-up to from previous work to add initial support the new JWT format in PR #8.

This PR focuses on making use of the additional per-project-resource information  provided in the new JWT format. This is done by changing the internal representation of the projects claim data (`auth-state`). See isambard-sc/jupyter-platform#76 (<https://github.com/isambard-sc/jupyter-platform/issues/76#issuecomment-2650522411>) for details.

Key changes:
* New `BricsAuthenticator.brics_platform` configuration traitlet that specifies the platform (resource name) being authenticated to
* Additional debug output (when logging is at debug level) showing decoded JWT + estimates of request header size and JWT token size
* New `BricsLoginHandler._auth_state_from_projects()` function that (i) transforms the projects claim from the JWT into a form suitable for processing by `BricsSlurmSpawner` in `auth_state`, (ii) filters `auth_state` to only include data for projects with at least one resource with a name  `BricsAuthenticator.brics_platform` is present
* Remove support for old JWT format from `BricsLoginHandler._normalize_projects()`
* Update `BricsSlurmSpawner`  to use new `auth_state` format
  * `BricsSlurmSpawner.brics_project_user_name` updated to use per-project username instead of constructing this from user short name and project short_name
  * `BricsSlurmSpawner._req_homedir_default` updated to support `<PROJECT_SHORTNAME>.<PORTAL_SHORTNAME>` project short names (used in new JWT format)
* Update `spawner_options_form` module functions to support new `auth_state` format
  * HTML generated spawner options form now uses both short name and human-readable name from `auth_state` in the `<select>` control
  * Regular expression for validating project name updated to enforce `<PROJECT_SHORTNAME>.<PORTAL_SHORTNAME>` format
* Existing unit tests updated based on all changes
* New unit test for `_auth_state_from_projects()`
* New unit test to check `BricsLoginHandler.get()` produces expected HTTP 403 error when no valid projects are present in the JWT

This new code has been tested with with a dev JupyterHub instance connected to a Zenith tunnel where HTTP requests included new format JWTs. Key behaviour of the application with the updated authentication code:

* Requests with JWT that have no projects, or only projects which do not have the required resource name (e.g. `brics.aip1.notebooks.shared`) receive a HTTP 403 and the user is not authenticated
* Requests with JWT that have one or more projects with required resource name (e.g. `brics.aip1.notebooks.shared`)  are authenticated to JupyterHub, and are only able to spawn to projects with the required resource name