### PR TITLE
Fix user server/session persistence on JupyterHub restart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,12 @@ version_file = "src/bricsauthenticator/_version.py"
 remove-all-unused-imports = true
 ignore-init-module-imports = true
 remove-unused-variables = true
+exclude = ["src/bricsauthenticator/_version.py"]
 
 [tool.isort]
 line_length = 120
 profile = 'black'
+skip = ["src/bricsauthenticator/_version.py"]
 
 [tool.black]
 line-length = 120

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -158,7 +158,7 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         Restore state of :class:`BricsSlurmSpawner` after hub process restarts
 
         Overrides :func:`BatchSpawnerBase.loadstate` to add additional state
-        specific to :class:`BricsSlurmSpawner`. 
+        specific to :class:`BricsSlurmSpawner`.
 
         :param state: dict containing state loaded from database
         """
@@ -172,7 +172,7 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         Save state of :class:`BricsSlurmSpawner` into database
 
         Overrides :func:`BatchSpawnerBase.loadstate` to add additional state
-        specific to :class:`BricsSlurmSpawner`. 
+        specific to :class:`BricsSlurmSpawner`.
 
         :return: a JSONable dict of state to persist in the database
         """
@@ -184,13 +184,13 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
     def clear_state(self) -> None:
         """
         Clear state of :class:`BricsSlurmSpawner` when single user server is stopped
-        
+
         Overrides :func:`BatchSpawnerBase.loadstate` to add additional state
-        specific to :class:`BricsSlurmSpawner`. 
+        specific to :class:`BricsSlurmSpawner`.
 
         .. note::
-            
+
             There is currently no additional state to clear as `brics_projects`
-            should be persisted between single-user server instances. 
+            should be persisted between single-user server instances.
         """
         super().clear_state()

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -24,6 +24,8 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         
         Should be set by Authenticator via Spawner.auth_state_hook()
         """,
+        allow_none=True,
+        default_value=None,
     )
 
     def __init__(
@@ -162,7 +164,9 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         :param state: dict containing state loaded from database
         """
         super().load_state(state)
+        self.log.debug("Loading state: brics_projects")
         self.brics_projects = state["brics_projects"]
+        self.log.debug(f"Acquired brics_projects: {self.brics_projects}")
 
     def get_state(self) -> dict:
         """
@@ -174,7 +178,9 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         :return: a JSONable dict of state to persist in the database
         """
         state = super().get_state()
+        self.log.debug("Saving state: brics_projects")
         state["brics_projects"] = self.brics_projects
+        self.log.debug(f"To save brics_projects: {brics_projects}")
         return state
 
     def clear_state(self) -> None:

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -151,3 +151,42 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         env["HOME"] = self.req_homedir
         env["SHELL"] = "/bin/bash"
         return env
+
+    def load_state(self, state: dict) -> None:
+        """
+        Restore state of :class:`BricsSlurmSpawner` after hub process restarts
+
+        Overrides :func:`BatchSpawnerBase.loadstate` to add additional state
+        specific to :class:`BricsSlurmSpawner`. 
+
+        :param state: dict containing state loaded from database
+        """
+        super().load_state(state)
+        self.brics_projects = state["brics_projects"]
+
+    def get_state(self) -> dict:
+        """
+        Save state of :class:`BricsSlurmSpawner` into database
+
+        Overrides :func:`BatchSpawnerBase.loadstate` to add additional state
+        specific to :class:`BricsSlurmSpawner`. 
+
+        :return: a JSONable dict of state to persist in the database
+        """
+        state = super().get_state()
+        state["brics_projects"] = self.brics_projects
+        return state
+
+    def clear_state(self) -> None:
+        """
+        Clear state of :class:`BricsSlurmSpawner` when single user server is stopped
+        
+        Overrides :func:`BatchSpawnerBase.loadstate` to add additional state
+        specific to :class:`BricsSlurmSpawner`. 
+
+        .. note::
+            
+            There is currently no additional state to clear as `brics_projects`
+            should be persisted between single-user server instances. 
+        """
+        super().clear_state()

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -24,8 +24,7 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         
         Should be set by Authenticator via Spawner.auth_state_hook()
         """,
-        allow_none=True,
-        default_value=None,
+        default_value=dict(),
     )
 
     def __init__(

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -164,9 +164,11 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         :param state: dict containing state loaded from database
         """
         super().load_state(state)
-        self.log.debug("Loading state: brics_projects")
-        self.brics_projects = state["brics_projects"]
-        self.log.debug(f"Acquired brics_projects: {self.brics_projects}")
+        if "brics_projects" in state:
+            self.brics_projects = state["brics_projects"]
+            self.log.debug(f"BricsSlurmSpawner.load_state() acquired brics_projects: {self.brics_projects}")
+        else:
+            
 
     def get_state(self) -> dict:
         """
@@ -178,9 +180,8 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         :return: a JSONable dict of state to persist in the database
         """
         state = super().get_state()
-        self.log.debug("Saving state: brics_projects")
         state["brics_projects"] = self.brics_projects
-        self.log.debug(f"To save brics_projects: {brics_projects}")
+        self.log.debug(f"BricsSlurmSpawner saving brics_projects: {brics_projects}")
         return state
 
     def clear_state(self) -> None:

--- a/src/bricsauthenticator/spawner.py
+++ b/src/bricsauthenticator/spawner.py
@@ -167,8 +167,6 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         if "brics_projects" in state:
             self.brics_projects = state["brics_projects"]
             self.log.debug(f"BricsSlurmSpawner.load_state() acquired brics_projects: {self.brics_projects}")
-        else:
-            
 
     def get_state(self) -> dict:
         """
@@ -181,7 +179,7 @@ class BricsSlurmSpawner(batchspawner.SlurmSpawner):
         """
         state = super().get_state()
         state["brics_projects"] = self.brics_projects
-        self.log.debug(f"BricsSlurmSpawner saving brics_projects: {brics_projects}")
+        self.log.debug(f"BricsSlurmSpawner saving brics_projects: {self.brics_projects}")
         return state
 
     def clear_state(self) -> None:

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock
 
 from bricsauthenticator.spawner import BricsSlurmSpawner
 
+import pytest
+
 
 def test_auth_state_hook_default():
     spawner = BricsSlurmSpawner()
@@ -90,3 +92,30 @@ def test_req_homedir_default():
 
     # Assert the expected result
     assert result == "/home/project1/test_user.project1"
+
+@pytest.fixture
+def spawner_with_brics_projects() -> BricsSlurmSpawner:
+    """
+    :class:`BricsSlurmSpawner` instance with `brics_projects` attribute set
+    """
+
+    spawner = BricsSlurmSpawner()
+    spawner.brics_projects = {"project1.portal": {"name": "Project 1", "username": "test_user.project1"}}
+
+    return spawner
+
+def test_load_state(spawner_with_brics_projects: BricsSlurmSpawner):
+    """
+    Check :func:`load_state` method returns the expected `state`
+    """
+
+    spawner = BricsSlurmSpawner()
+
+    assert spawner.brics_projects == dict(), "default brics_projects should be empty dict"
+
+    state = {"brics_projects": spawner_with_brics_projects.brics_projects}
+
+    spawner.load_state(state)
+
+    assert spawner.brics_projects == state["brics_projects"], "after load_state brics_projects should be populated"
+

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock
 
-from bricsauthenticator.spawner import BricsSlurmSpawner
-
 import pytest
+
+from bricsauthenticator.spawner import BricsSlurmSpawner
 
 
 def test_auth_state_hook_default():
@@ -93,17 +93,20 @@ def test_req_homedir_default():
     # Assert the expected result
     assert result == "/home/project1/test_user.project1"
 
+
 @pytest.fixture(
-    params = [
+    params=[
         pytest.param(dict(), id="empty dict"),
-        pytest.param({"project1.portal": {"name": "Project 1", "username": "test_user.project1"}}, id="1 example project"),
+        pytest.param(
+            {"project1.portal": {"name": "Project 1", "username": "test_user.project1"}}, id="1 example project"
+        ),
         pytest.param(
             {
                 "project1.portal": {"name": "Project 1", "username": "test_user.project1"},
                 "project2.portal": {"name": "Project 2", "username": "test_user.project2"},
-            }, 
-            id="2 example project"
-        )
+            },
+            id="2 example project",
+        ),
     ]
 )
 def brics_projects(request: pytest.FixtureRequest) -> dict:
@@ -122,7 +125,10 @@ def test_load_state(brics_projects: dict):
     state = {"brics_projects": brics_projects}
     spawner.load_state(state)
 
-    assert spawner.brics_projects == state["brics_projects"], "after load_state() call brics_projects should be populated"
+    assert (
+        spawner.brics_projects == state["brics_projects"]
+    ), "after load_state() call brics_projects should be populated"
+
 
 def test_get_state(brics_projects: dict):
     """
@@ -136,7 +142,10 @@ def test_get_state(brics_projects: dict):
 
     state = spawner.get_state()
 
-    assert state["brics_projects"] == expected_state["brics_projects"], "state from get_state() should contain 'brics_projects' key with expected value"
+    assert (
+        state["brics_projects"] == expected_state["brics_projects"]
+    ), "state from get_state() should contain 'brics_projects' key with expected value"
+
 
 def test_clear_state_brics_projects(brics_projects: dict):
     """


### PR DESCRIPTION
Fix an issue where single-user servers do not persist between restarts of JupyterHub because `BricsSlurmSpawner` did not restore the state of the `brics_projects` attribute from the database.

This solution has been tested in dev environments from [brics_jupyterhub_envs](https://github.com/isambard-sc/brics_jupyterhub_envs): `dev_dummyauth` and `dev_realauth_zenithclient`. In both cases it was found that with the changes in this PR, JupyterHub was able to recover the state and reconnect to running single-user servers after the JupyterHub container was restarted.

Some simple unit tests are included for the new `BricsSlurmSpawner.{get,load,clear}_state()` methods.