### PR TITLE
Improved log out handling + remove Codecov

### DIFF
--- a/.github/workflows/build_lint_test.yml
+++ b/.github/workflows/build_lint_test.yml
@@ -59,20 +59,12 @@ jobs:
       if: matrix.python-version == env.PYTHON_VERSION_COVERAGE_UPLOAD
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-report
+        name: html-coverage-report-${{ github.run_id }}
         path: htmlcov
-
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == env.PYTHON_VERSION_COVERAGE_UPLOAD
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: coverage.xml
-        fail_ci_if_error: false
 
     - name: Upload coverage artifact
       if: matrix.python-version == env.PYTHON_VERSION_COVERAGE_UPLOAD
       uses: actions/upload-artifact@v4
       with:
-        name: ccoverage-report-${{ github.run_id }} 
+        name: xml-coverage-report-${{ github.run_id }} 
         path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # bricsauthenticator
 
-[![codecov](https://codecov.io/gh/owhere/bricsauthenticator/branch/tests/graph/badge.svg?token=3IGKBYAIS1)](https://codecov.io/gh/owhere/bricsauthenticator)
-
 JupyterHub `Authenticator` and `Spawner` for the BriCS JupyterHub service
 
 ## Install

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 85  

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -194,7 +194,7 @@ class BricsLoginHandler(BaseHandler):
 
 class BricsLogoutHandler(LogoutHandler):
     async def render_logout_page(self):
-        redirect_url=f"/_oidc/sign_out?rd={urllib.parse.encode('/jupyter', safe='')}"
+        redirect_url=f"{self.hub.base_url}/_oidc/sign_out?rd={urllib.parse.encode('/jupyter', safe='')}"
         self.log.debug(f"BricsLogoutHandler redirecting to {redirect_url}")
         self.redirect(redirect_url)
 

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -204,6 +204,7 @@ class BricsLogoutHandler(LogoutHandler):
             self.log.debug("BricsLogoutHandler delegating to parent render_logout_page()")
             super().render_logout_page()
 
+
 class BricsAuthenticator(Authenticator):
 
     oidc_server = Unicode(
@@ -248,13 +249,7 @@ class BricsAuthenticator(Authenticator):
                     "jwt_leeway": self.jwt_leeway,
                 },
             ),
-            (
-                r"/logout",
-                BricsLogoutHandler,
-                {
-                    "logout_redirect_url": self.logout_redirect_url
-                }
-            )
+            (r"/logout", BricsLogoutHandler, {"logout_redirect_url": self.logout_redirect_url}),
         ]
 
     async def authenticate(self, *args, **kwargs):

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -194,7 +194,7 @@ class BricsLoginHandler(BaseHandler):
 
 class BricsLogoutHandler(LogoutHandler):
     async def render_logout_page(self):
-        redirect_url=f"{self.hub.base_url}/_oidc/sign_out?rd={urllib.parse.quote('/jupyter', safe='')}"
+        redirect_url=f"{self.base_url}_oidc/sign_out?rd={urllib.parse.quote('/jupyter', safe='')}"
         self.log.debug(f"BricsLogoutHandler redirecting to {redirect_url}")
         self.redirect(redirect_url)
 

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -10,7 +10,7 @@ from jupyterhub.auth import Authenticator
 from jupyterhub.handlers import BaseHandler, LogoutHandler
 from tornado import web
 from tornado.httpclient import AsyncHTTPClient
-from traitlets import Float, Unicode
+from traitlets import Bool, Float, Unicode
 
 
 class BricsLoginHandler(BaseHandler):
@@ -20,6 +20,7 @@ class BricsLoginHandler(BaseHandler):
         platform: str,
         jwt_audience: str,
         jwt_leeway: float,
+        invalid_jwt_logout: bool,
         http_client=None,
         jwks_client_factory=None,
     ):
@@ -27,12 +28,19 @@ class BricsLoginHandler(BaseHandler):
         self.platform = platform
         self.jwt_audience = jwt_audience
         self.jwt_leeway = jwt_leeway
+        self.invalid_jwt_logout = invalid_jwt_logout
         self.http_client = http_client or AsyncHTTPClient()
         self.jwks_client_factory = jwks_client_factory or self._default_jwks_client_factory
 
     def _default_jwks_client_factory(self, jwks_uri: str):
         headers = {"User-Agent": f"PyJWT/{jwt.__version__}"}
         return jwt.PyJWKClient(jwks_uri, headers=headers)
+
+    def _logout_redirect(self):
+        self.redirect("/logout")
+        # TODO Determine whether raising web.Finish here is necessary (i.e. does `redirect` do the equivalent of 
+        #    raising this itself?)
+        raise web.Finish
 
     async def get(self):
 
@@ -54,12 +62,18 @@ class BricsLoginHandler(BaseHandler):
 
         username = decoded_token.get("short_name")
         if not username:
-            raise web.HTTPError(401, "Invalid token: Missing short_name claim")
+            if self.invalid_jwt_logout:
+                self._logout_redirect()
+            else:
+                raise web.HTTPError(401, "Invalid token: Missing short_name claim")
 
         auth_state = self._auth_state_from_projects(projects, self.platform)
 
         if not len(auth_state) > 0:
-            raise web.HTTPError(403, "No projects with valid platform")
+            if self.invalid_jwt_logout:
+                self._logout_redirect()
+            else:
+                raise web.HTTPError(403, "No projects with valid platform")
 
         user = await self.auth_to_user({"name": username, "auth_state": auth_state})
         self.set_login_cookie(user)
@@ -107,7 +121,10 @@ class BricsLoginHandler(BaseHandler):
                 leeway=self.jwt_leeway,  # time skew tolerance
             )
         except jwt.InvalidTokenError as e:
-            raise web.HTTPError(401, f"Invalid JWT token: {str(e)}")
+            if self.invalid_jwt_logout:
+                self._logout_redirect()
+            else:
+                raise web.HTTPError(401, f"Invalid JWT token: {str(e)}")
 
     def _normalize_projects(self, decoded_token: dict) -> dict:
         projects = decoded_token.get("projects")
@@ -237,6 +254,12 @@ class BricsAuthenticator(Authenticator):
         allow_none=True,
     ).tag(config=True)
 
+    invalid_jwt_logout = Bool(
+        default_value=True,
+        help="If True, redirect to /logout when an invalid JWT is encountered instead of showing HTTP error page",
+        allow_none=False,
+    ).tag(config=True)
+
     def get_handlers(self, app):
         return [
             (
@@ -247,6 +270,7 @@ class BricsAuthenticator(Authenticator):
                     "platform": self.brics_platform,
                     "jwt_audience": self.jwt_audience,
                     "jwt_leeway": self.jwt_leeway,
+                    "invalid_jwt_logout": self.invalid_jwt_logout,
                 },
             ),
             (r"/logout", BricsLogoutHandler, {"logout_redirect_url": self.logout_redirect_url}),

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -194,7 +194,7 @@ class BricsLoginHandler(BaseHandler):
 
 class BricsLogoutHandler(LogoutHandler):
     async def render_logout_page(self):
-        redirect_url=f"{self.hub.base_url}/_oidc/sign_out?rd={urllib.parse.encode('/jupyter', safe='')}"
+        redirect_url=f"{self.hub.base_url}/_oidc/sign_out?rd={urllib.parse.quote('/jupyter', safe='')}"
         self.log.debug(f"BricsLogoutHandler redirecting to {redirect_url}")
         self.redirect(redirect_url)
 

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -202,7 +202,7 @@ class BricsLogoutHandler(LogoutHandler):
             self.redirect(self.logout_redirect_url)
         else:
             self.log.debug("BricsLogoutHandler delegating to parent render_logout_page()")
-            super().render_logout_page()
+            await super().render_logout_page()
 
 
 class BricsAuthenticator(Authenticator):

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -39,8 +39,6 @@ class BricsLoginHandler(BaseHandler):
     def _logout_redirect(self):
         self.log.debug(f"BricsLoginHandler auto-redirecting to {self.settings['logout_url']}")
         self.redirect(self.settings["logout_url"])
-        # TODO Determine whether raising web.Finish here is necessary (i.e. does `redirect` do the equivalent of
-        #    raising this itself?)
         raise web.Finish
 
     async def get(self):

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -38,7 +38,7 @@ class BricsLoginHandler(BaseHandler):
 
     def _logout_redirect(self):
         self.redirect("/logout")
-        # TODO Determine whether raising web.Finish here is necessary (i.e. does `redirect` do the equivalent of 
+        # TODO Determine whether raising web.Finish here is necessary (i.e. does `redirect` do the equivalent of
         #    raising this itself?)
         raise web.Finish
 

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -3,6 +3,7 @@ JupyterHub `Authenticator` for the BriCS JupyterHub service
 """
 
 import json
+import urllib.parse
 
 import jwt
 from jupyterhub.auth import Authenticator
@@ -193,8 +194,9 @@ class BricsLoginHandler(BaseHandler):
 
 class BricsLogoutHandler(LogoutHandler):
     async def render_logout_page(self):
-        self.log.debug("BricsLogoutHandler entering render_logout_page()")
-        self.redirect("/_oidc/sign_in")
+        redirect_url=f"/_oidc/sign_out?rd={urllib.parse.encode('/jupyter', safe='')}"
+        self.log.debug(f"BricsLogoutHandler redirecting to {redirect_url}")
+        self.redirect(redirect_url)
 
 
 class BricsAuthenticator(Authenticator):

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -37,7 +37,8 @@ class BricsLoginHandler(BaseHandler):
         return jwt.PyJWKClient(jwks_uri, headers=headers)
 
     def _logout_redirect(self):
-        self.redirect("/logout")
+        self.log.debug(f"BricsLoginHandler auto-redirecting to {self.settings['logout_url']}")
+        self.redirect(self.settings["logout_url"])
         # TODO Determine whether raising web.Finish here is necessary (i.e. does `redirect` do the equivalent of
         #    raising this itself?)
         raise web.Finish

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -193,11 +193,16 @@ class BricsLoginHandler(BaseHandler):
 
 
 class BricsLogoutHandler(LogoutHandler):
-    async def render_logout_page(self):
-        redirect_url=f"{self.base_url}_oidc/sign_out?rd={urllib.parse.quote('/jupyter', safe='')}"
-        self.log.debug(f"BricsLogoutHandler redirecting to {redirect_url}")
-        self.redirect(redirect_url)
+    def initialize(logout_redirect_url: str | None):
+        self.logout_redirect_url = logout_redirect_url
 
+    async def render_logout_page(self):
+        if self.logout_redirect_url:
+            self.log.debug(f"BricsLogoutHandler redirecting to {self.logout_redirect_url}")
+            self.redirect(self.logout_redirect_url)
+        else:
+            self.log.debug(f"BricsLogoutHandler delegating to parent render_logout_page()")
+            super().render_logout_page()
 
 class BricsAuthenticator(Authenticator):
 
@@ -225,6 +230,12 @@ class BricsAuthenticator(Authenticator):
         allow_none=False,
     ).tag(config=True)
 
+    logout_redirect_url = Unicode(
+        default_value=f"/jupyter/_oidc/sign_out?rd={urllib.parse.quote('/jupyter', safe='')}",
+        help="A URL to redirect to after JupyterHub logout has been handled instead of the default",
+        allow_none=True,
+    ).tag(config=True)
+
     def get_handlers(self, app):
         return [
             (
@@ -239,7 +250,10 @@ class BricsAuthenticator(Authenticator):
             ),
             (
                 r"/logout",
-                BricsLogoutHandler
+                BricsLogoutHandler,
+                {
+                    "logout_redirect_url": self.logout_redirect_url
+                }
             )
         ]
 

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -193,7 +193,7 @@ class BricsLoginHandler(BaseHandler):
 
 
 class BricsLogoutHandler(LogoutHandler):
-    def initialize(logout_redirect_url: str | None):
+    def initialize(self, logout_redirect_url: str | None):
         self.logout_redirect_url = logout_redirect_url
 
     async def render_logout_page(self):
@@ -201,7 +201,7 @@ class BricsLogoutHandler(LogoutHandler):
             self.log.debug(f"BricsLogoutHandler redirecting to {self.logout_redirect_url}")
             self.redirect(self.logout_redirect_url)
         else:
-            self.log.debug(f"BricsLogoutHandler delegating to parent render_logout_page()")
+            self.log.debug("BricsLogoutHandler delegating to parent render_logout_page()")
             super().render_logout_page()
 
 class BricsAuthenticator(Authenticator):

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -37,7 +37,7 @@ class BricsLoginHandler(BaseHandler):
         return jwt.PyJWKClient(jwks_uri, headers=headers)
 
     def _logout_redirect(self):
-        self.log.debug(f"BricsLoginHandler auto-redirecting to {self.settings['logout_url']}")
+        self.log.info(f"BricsLoginHandler auto-redirecting to {self.settings['logout_url']}")
         self.redirect(self.settings["logout_url"])
         raise web.Finish
 
@@ -62,6 +62,7 @@ class BricsLoginHandler(BaseHandler):
         username = decoded_token.get("short_name")
         if not username:
             if self.invalid_jwt_logout:
+                self.log.info("Invalid token: Missing short_name claim")
                 self._logout_redirect()
             else:
                 raise web.HTTPError(401, "Invalid token: Missing short_name claim")
@@ -70,6 +71,7 @@ class BricsLoginHandler(BaseHandler):
 
         if not len(auth_state) > 0:
             if self.invalid_jwt_logout:
+                self.log.info("No projects with valid platform")
                 self._logout_redirect()
             else:
                 raise web.HTTPError(403, "No projects with valid platform")
@@ -121,6 +123,7 @@ class BricsLoginHandler(BaseHandler):
             )
         except jwt.InvalidTokenError as e:
             if self.invalid_jwt_logout:
+                self.log.info(f"Invalid JWT token: {str(e)}")
                 self._logout_redirect()
             else:
                 raise web.HTTPError(401, f"Invalid JWT token: {str(e)}")

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -6,7 +6,7 @@ import json
 
 import jwt
 from jupyterhub.auth import Authenticator
-from jupyterhub.handlers import BaseHandler
+from jupyterhub.handlers import BaseHandler, LogoutHandler
 from tornado import web
 from tornado.httpclient import AsyncHTTPClient
 from traitlets import Float, Unicode
@@ -191,6 +191,12 @@ class BricsLoginHandler(BaseHandler):
         return auth_state
 
 
+class BricsLogoutHandler(LogoutHandler):
+    async def render_logout_page(self):
+        self.log.debug("BricsLogoutHandler entering render_logout_page()")
+        self.redirect("/_oidc/sign_in")
+
+
 class BricsAuthenticator(Authenticator):
 
     oidc_server = Unicode(
@@ -228,6 +234,10 @@ class BricsAuthenticator(Authenticator):
                     "jwt_audience": self.jwt_audience,
                     "jwt_leeway": self.jwt_leeway,
                 },
+            ),
+            (
+                r"/logout",
+                BricsLogoutHandler
             )
         ]
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -597,11 +597,15 @@ class TestBricsLogoutHandler:
     @pytest.mark.asyncio
     async def test_render_logout_page_with_redirect(self, handler):
 
-        # await handler.render_logout_page()
+        handler.redirect = MagicMock()
+        await handler.render_logout_page()
 
         # Check that `handler.redirect` is called with expected argument
+        mock_calls = handler.redirect.mock_calls
+        assert len(mock_calls) == 1
+        assert len(mock_calls[0].args) == 1
+        assert mock_calls[0].args[0] == handler.logout_redirect_url
 
-        raise NotImplementedError
 
     @pytest.mark.asyncio
     async def test_render_logout_page_default(self, handler):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -12,6 +12,7 @@ from tornado.web import Application, HTTPError
 
 from bricsauthenticator.auth import BricsAuthenticator, BricsLoginHandler, BricsLogoutHandler
 
+
 class TestBricsAuthenticator:
 
     def test_get_handlers(self):
@@ -36,6 +37,7 @@ class TestBricsAuthenticator:
         assert handlers[1][1] == BricsLogoutHandler
         assert len(handlers[1][2]) == 1
         assert handlers[1][2]["logout_redirect_url"] == authenticator.logout_redirect_url
+
 
 class TestBricsLoginHandler:
 
@@ -67,58 +69,51 @@ class TestBricsLoginHandler:
         handler_instance.jwks_client_factory = MagicMock()
         return handler_instance
 
-
     def test_extract_token_missing_header(self, handler):
         handler.request.headers = HTTPHeaders({})
         with pytest.raises(HTTPError) as exc_info:
             handler._extract_token()
         assert exc_info.value.status_code == 401
         assert "Missing X-Auth-Id-Token header" in str(exc_info.value)
-    
-    
+
     def test_extract_token_success(self, handler):
         handler.request.headers = HTTPHeaders({"X-Auth-Id-Token": "fake_token"})
         token = handler._extract_token()
         assert token == "fake_token"
-    
-    
+
     @pytest.mark.asyncio
     async def test_fetch_oidc_config_success(self, handler):
         mock_response = AsyncMock()
         mock_response.body = b'{"key": "value"}'
         handler.http_client.fetch.return_value = mock_response
-    
+
         config = await handler._fetch_oidc_config()
         assert config == {"key": "value"}
-    
-    
+
     @pytest.mark.asyncio
     async def test_fetch_oidc_config_failure(self, handler):
         handler.http_client.fetch.side_effect = Exception("Fetch error")
         with pytest.raises(HTTPError) as exc_info:
             await handler._fetch_oidc_config()
         assert exc_info.value.status_code == 500
-    
-    
+
     def test_parse_oidc_config(self, handler):
         oidc_config = {"id_token_signing_alg_values_supported": ["RS256"], "jwks_uri": "https://example.com/jwks_uri"}
         signing_algos, jwks_uri = handler._parse_oidc_config(oidc_config)
         assert signing_algos == ["RS256"]
         assert jwks_uri == "https://example.com/jwks_uri"
-    
-    
+
     def test_fetch_signing_key(self, handler):
         mock_jwks_client = MagicMock()
         handler.jwks_client_factory.return_value = mock_jwks_client
         mock_signing_key = MagicMock()
         mock_jwks_client.get_signing_key_from_jwt.return_value = mock_signing_key
-    
+
         signing_key = handler._fetch_signing_key("https://example.com/jwks_uri", "fake_token")
         assert signing_key == mock_signing_key
         handler.jwks_client_factory.assert_called_with("https://example.com/jwks_uri")
         mock_jwks_client.get_signing_key_from_jwt.assert_called_with("fake_token")
-    
-    
+
     def test_decode_jwt_success(self, handler):
         handler.jwt_audience = "zenith-jupyter"  # Match token's "aud" claim
         decoded_token = {
@@ -131,36 +126,32 @@ class TestBricsLoginHandler:
         }
         mock_signing_key = MagicMock()
         mock_signing_key.key = "fake_key"
-    
+
         with patch("jwt.decode", return_value=decoded_token):
             result = handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
             assert result == decoded_token
             assert result == decoded_token
-    
-    
+
     def test_decode_jwt_failure(self, handler):
         handler.jwt_audience = "zenith-jupyter"
         mock_signing_key = MagicMock()
         mock_signing_key.key = "fake_key"
-    
+
         with patch("jwt.decode", side_effect=jwt.InvalidTokenError("Invalid token")):
             with pytest.raises(HTTPError) as exc_info:
                 handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
             assert exc_info.value.status_code == 401
-    
-    
+
     def test_normalize_projects_invalid_json(self, handler):
         decoded_token = {"projects": "invalid_json"}
         result = handler._normalize_projects(decoded_token)
         assert result == {}  # Expect an empty dict instead of a raw string
-    
-    
+
     def test_normalize_projects_none(self, handler):
         decoded_token = {}
         result = handler._normalize_projects(decoded_token)
         assert result == {}
-    
-    
+
     @pytest.mark.parametrize(
         "platform,normalized_projects,expected_result",
         [
@@ -250,8 +241,7 @@ class TestBricsLoginHandler:
     def test_auth_state_from_projects(self, handler, platform: str, normalized_projects: dict, expected_result: dict):
         result = handler._auth_state_from_projects(projects=normalized_projects, platform=platform)
         assert result == expected_result
-    
-    
+
     @pytest.mark.asyncio
     async def test_get(self):
         # Create a real Application instance with necessary settings
@@ -260,12 +250,12 @@ class TestBricsLoginHandler:
             "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
             "cookie_secret": b"secret",  # Add other required settings
         }
-    
+
         # Mock request with a connection attribute
         request = MagicMock(spec=HTTPServerRequest)
         request.connection = MagicMock()  # Add the 'connection' attribute
         request.headers = HTTPHeaders({"X-Auth-Id-Token": "fake_token"})
-    
+
         # Create an instance of the handler
         handler = BricsLoginHandler(
             application,
@@ -275,7 +265,7 @@ class TestBricsLoginHandler:
             jwt_audience="dummy-audience",
             jwt_leeway=5,
         )
-    
+
         # Mock handler dependencies
         handler._extract_token = MagicMock(return_value="mock_token")
         handler._fetch_oidc_config = AsyncMock(
@@ -300,10 +290,10 @@ class TestBricsLoginHandler:
         handler.set_login_cookie = MagicMock()
         handler.get_next_url = MagicMock(return_value="/home")
         handler.redirect = MagicMock()
-    
+
         # Call the actual `get` method
         await handler.get()
-    
+
         # Assertions
         handler._extract_token.assert_called_once()
         handler._fetch_oidc_config.assert_called_once()
@@ -317,8 +307,7 @@ class TestBricsLoginHandler:
         handler.auth_to_user.assert_called_once_with({"name": "test_user", "auth_state": auth_state})
         handler.set_login_cookie.assert_called_once_with(user)
         handler.redirect.assert_called_once_with("/home")
-    
-    
+
     @pytest.mark.parametrize(
         "platform, projects",
         [
@@ -347,13 +336,13 @@ class TestBricsLoginHandler:
     @pytest.mark.asyncio
     async def test_get_no_valid_projects_exception(self, handler, platform: str, projects: dict[str, dict]):
         handler.platform = platform
-    
+
         # Mock all methods up until a the token is decoded
         handler._extract_token = MagicMock()
         handler._fetch_oidc_config = AsyncMock()
         handler._parse_oidc_config = MagicMock(return_value=(MagicMock, MagicMock))
         handler._fetch_signing_key = MagicMock()
-    
+
         decoded_token = {
             "aud": "zenith-jupyter",
             "exp": 12345,
@@ -362,18 +351,15 @@ class TestBricsLoginHandler:
             "short_name": "user",
             "projects": projects,
         }
-    
+
         # Mock the JWT decoding function and its return value
         handler._decode_jwt = MagicMock(return_value=decoded_token)
-    
+
         with pytest.raises(HTTPError, match="No projects with valid platform") as exc_info:
             await handler.get()
-    
+
         assert exc_info.value.status_code == 403
-    
-    
-    
-    
+
     @pytest.mark.parametrize(
         "decoded_token, expected_output",
         [
@@ -438,7 +424,9 @@ class TestBricsLoginHandler:
             # Null `projects` value should return empty
             pytest.param({"projects": None}, {}, id="Projects None - return empty"),
             # JSON-encoded list (invalid case)
-            pytest.param({"projects": json.dumps([{"name": "test.resource"}])}, {}, id="JSON encoded list - invalid case"),
+            pytest.param(
+                {"projects": json.dumps([{"name": "test.resource"}])}, {}, id="JSON encoded list - invalid case"
+            ),
         ],
     )
     def test_normalize_projects(self, handler, decoded_token, expected_output):
@@ -448,8 +436,7 @@ class TestBricsLoginHandler:
         """
         result = handler._normalize_projects(decoded_token)
         assert result == expected_output
-    
-    
+
     @pytest.mark.parametrize(
         "leeway_seconds, delta_seconds, with_leeway_cm",
         [
@@ -461,33 +448,36 @@ class TestBricsLoginHandler:
             ),
             pytest.param(3.5, 1, nullcontext(), id="3.5s leeway, 1s delta"),
             pytest.param(
-                3.5, 4, pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)"), id="3.5s leeway, 4s delta"
+                3.5,
+                4,
+                pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)"),
+                id="3.5s leeway, 4s delta",
             ),
         ],
     )
-    def test_jwt_iat_validation_with_leeway(self, 
-        freezer, handler, leeway_seconds: int | float, delta_seconds: int, with_leeway_cm: AbstractContextManager
+    def test_jwt_iat_validation_with_leeway(
+        self, freezer, handler, leeway_seconds: int | float, delta_seconds: int, with_leeway_cm: AbstractContextManager
     ):
         """
         Check that JWTs with iat less than or equal to current time + leeway are valid
         """
-    
+
         signing_key = MagicMock(spec=jwt.PyJWK)
         signing_key.key = "test-secret"
         algorithm = "HS256"
-    
+
         # Freeze time to so that there is zero time between token setup and validation
         # Set microsecond=0 to ensure that there are no rounding errors from using
         # integer iat and exp claims
         frozen_time = datetime.datetime.now().replace(microsecond=0)
         freezer.move_to(frozen_time)
-    
+
         # Simulate a token with delta seconds in the future
         iat_adjusted = int(time.time() + delta_seconds)
-    
+
         # ... that expires 5 minutes after it is issued
         exp = int(iat_adjusted + timedelta(minutes=5).total_seconds())
-    
+
         payload = {
             "iat": iat_adjusted,
             "exp": exp,
@@ -501,23 +491,22 @@ class TestBricsLoginHandler:
                 }
             },
         }
-    
+
         token = jwt.encode(payload, signing_key.key, algorithm=algorithm)
-    
+
         # Without leeway, this should fail
         with pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)") as exc_info:
             handler.jwt_leeway = 0
             _ = handler._decode_jwt(token, signing_key, [algorithm])
-    
+
         assert exc_info.value.status_code == 401
-    
+
         # With leeway, it should succeed if not delta_seconds > leeway_seconds
         with with_leeway_cm:
             handler.jwt_leeway = leeway_seconds
             decoded = handler._decode_jwt(token, signing_key, [algorithm])
             assert decoded == payload
-    
-    
+
     @pytest.mark.parametrize(
         "leeway_seconds, delta_seconds, with_leeway_cm",
         [
@@ -529,29 +518,29 @@ class TestBricsLoginHandler:
             pytest.param(3.5, 4, pytest.raises(HTTPError, match=r"Signature has expired"), id="3.5s leeway, 4s delta"),
         ],
     )
-    def test_jwt_exp_validation_with_leeway(self, 
-        freezer, handler, leeway_seconds: int | float, delta_seconds: int, with_leeway_cm: AbstractContextManager
+    def test_jwt_exp_validation_with_leeway(
+        self, freezer, handler, leeway_seconds: int | float, delta_seconds: int, with_leeway_cm: AbstractContextManager
     ):
         """
         Check that JWTs with exp greater than current time - leeway are valid
         """
-    
+
         signing_key = MagicMock(spec=jwt.PyJWK)
         signing_key.key = "test-secret"
         algorithm = "HS256"
-    
+
         # Freeze time to so that there is zero time between token setup and validation
         # Set microsecond=0 to ensure that there are no rounding errors from using
         # integer iat and exp claims
         frozen_time = datetime.datetime.now().replace(microsecond=0)
         freezer.move_to(frozen_time)
-    
+
         # Simulate a token with iat 5 minutes + delta_seconds in the past
         iat = int(time.time() - timedelta(minutes=5).total_seconds() - delta_seconds)
-    
+
         # ... that expires 5 minutes after it is issued and delta_seconds before now
         exp = int(time.time() - delta_seconds)
-    
+
         payload = {
             "iat": iat,
             "exp": exp,
@@ -565,16 +554,16 @@ class TestBricsLoginHandler:
                 }
             },
         }
-    
+
         token = jwt.encode(payload, signing_key.key, algorithm=algorithm)
-    
+
         # Without leeway, this should fail
         with pytest.raises(HTTPError, match=r"Signature has expired") as exc_info:
             handler.jwt_leeway = 0
             _ = handler._decode_jwt(token, signing_key, [algorithm])
-    
+
         assert exc_info.value.status_code == 401
-    
+
         # With leeway, it should succeed if not delta_seconds >= leeway_seconds
         with with_leeway_cm:
             handler.jwt_leeway = leeway_seconds
@@ -590,8 +579,8 @@ class TestBricsLogoutHandler:
         application = Application()
         application.settings = {
             "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
-            #"cookie_secret": b"secret",  # Add other required settings
-            #"log_function": MagicMock(),  # Mock the application-level logger
+            # "cookie_secret": b"secret",  # Add other required settings
+            # "log_function": MagicMock(),  # Mock the application-level logger
         }
 
         # Mock request with a connection attribute and empty headers
@@ -601,28 +590,25 @@ class TestBricsLogoutHandler:
 
         # Initialize BricsLogoutHandler with the mocked application, request, and required arguments
         handler_instance = BricsLogoutHandler(
-            application,
-            request,
-            logout_redirect_url="/app/endpoint/sign_out?param=value"
+            application, request, logout_redirect_url="/app/endpoint/sign_out?param=value"
         )
         return handler_instance
 
     @pytest.mark.asyncio
     async def test_render_logout_page_with_redirect(self, handler):
 
-        #await handler.render_logout_page()
+        # await handler.render_logout_page()
 
         # Check that `handler.redirect` is called with expected argument
 
         raise NotImplementedError
-
 
     @pytest.mark.asyncio
     async def test_render_logout_page_default(self, handler):
 
         handler.logout_redirect_url = None
 
-        #await handler.render_logout_page()
+        # await handler.render_logout_page()
 
         # Check that `super().render_logout_page` is called
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -627,8 +627,6 @@ class TestBricsLogoutHandler:
         application = Application()
         application.settings = {
             "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
-            # "cookie_secret": b"secret",  # Add other required settings
-            # "log_function": MagicMock(),  # Mock the application-level logger
         }
 
         # Mock request with a connection attribute and empty headers

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -50,6 +50,7 @@ class TestBricsLoginHandler:
             "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
             "cookie_secret": b"secret",  # Add other required settings
             "log_function": MagicMock(),  # Mock the application-level logger
+            "logout_url": "/hub/logout",
         }
 
         # Mock request with a connection attribute and empty headers
@@ -77,7 +78,7 @@ class TestBricsLoginHandler:
             with pytest.raises(Finish):
                 handler._logout_redirect()
 
-            assert mock_redirect.mock_calls == [call("/logout")]
+            assert mock_redirect.mock_calls == [call(handler.settings["logout_url"])]
 
     def test_extract_token_missing_header(self, handler):
         handler.request.headers = HTTPHeaders({})
@@ -155,7 +156,7 @@ class TestBricsLoginHandler:
             with pytest.raises(Finish):
                 handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
 
-            assert mock_redirect.mock_calls == [call("/logout")]
+            assert mock_redirect.mock_calls == [call(handler.settings["logout_url"])]
 
     def test_decode_jwt_failure_with_exception(self, handler):
         handler.jwt_audience = "zenith-jupyter"
@@ -394,7 +395,7 @@ class TestBricsLoginHandler:
             with pytest.raises(Finish):
                 await no_valid_projects_handler.get()
 
-            assert mock_redirect.mock_calls == [call("/logout")]
+            assert mock_redirect.mock_calls == [call(no_valid_projects_handler.settings["logout_url"])]
 
     @pytest.mark.asyncio
     async def test_get_no_valid_projects_exception(self, no_valid_projects_handler: BricsLoginHandler):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -623,6 +623,6 @@ class TestBricsLogoutHandler:
             assert len(mock_calls) == 1
             assert len(mock_calls[0].args) == 0
 
-            # Check that `BricsLogoutHandler.redirect`` is not called
+            # Check that `BricsLogoutHandler.redirect` is not called
             mock_calls = mock_redirect
             assert len(mock_calls) == 0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -612,8 +612,17 @@ class TestBricsLogoutHandler:
 
         handler.logout_redirect_url = None
 
-        # await handler.render_logout_page()
+        with (
+            patch("bricsauthenticator.auth.LogoutHandler.render_logout_page") as mock_parent_render_logout_page,
+            patch("bricsauthenticator.auth.BricsLogoutHandler.redirect") as mock_redirect
+        ):
+            await handler.render_logout_page()
 
-        # Check that `super().render_logout_page` is called
+            # Check that `super().render_logout_page` is called
+            mock_calls = mock_parent_render_logout_page.mock_calls
+            assert len(mock_calls) == 1
+            assert len(mock_calls[0].args) == 0
 
-        raise NotImplementedError
+            # Check that `BricsLogoutHandler.redirect`` is not called
+            mock_calls = mock_redirect
+            assert len(mock_calls) == 0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -580,3 +580,50 @@ class TestBricsLoginHandler:
             handler.jwt_leeway = leeway_seconds
             decoded = handler._decode_jwt(token, signing_key, [algorithm])
             assert decoded == payload
+
+
+class TestBricsLogoutHandler:
+
+    @pytest.fixture
+    def handler(self):
+        # Create a real Application instance with necessary settings
+        application = Application()
+        application.settings = {
+            "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
+            #"cookie_secret": b"secret",  # Add other required settings
+            #"log_function": MagicMock(),  # Mock the application-level logger
+        }
+
+        # Mock request with a connection attribute and empty headers
+        request = MagicMock(spec=HTTPServerRequest)
+        request.connection = MagicMock()  # Add the 'connection' attribute
+        request.headers = HTTPHeaders({})
+
+        # Initialize BricsLogoutHandler with the mocked application, request, and required arguments
+        handler_instance = BricsLogoutHandler(
+            application,
+            request,
+            logout_redirect_url="/app/endpoint/sign_out?param=value"
+        )
+        return handler_instance
+
+    @pytest.mark.asyncio
+    async def test_render_logout_page_with_redirect(self, handler):
+
+        #await handler.render_logout_page()
+
+        # Check that `handler.redirect` is called with expected argument
+
+        raise NotImplementedError
+
+
+    @pytest.mark.asyncio
+    async def test_render_logout_page_default(self, handler):
+
+        handler.logout_redirect_url = None
+
+        #await handler.render_logout_page()
+
+        # Check that `super().render_logout_page` is called
+
+        raise NotImplementedError

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,12 +3,12 @@ import json
 import time
 from contextlib import AbstractContextManager, nullcontext
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import jwt
 import pytest
 from tornado.httputil import HTTPHeaders, HTTPServerRequest
-from tornado.web import Application, HTTPError
+from tornado.web import Application, HTTPError, Finish
 
 from bricsauthenticator.auth import BricsAuthenticator, BricsLoginHandler, BricsLogoutHandler
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,11 +27,12 @@ class TestBricsAuthenticator:
         assert len(handlers) == 2
         assert handlers[0][0] == r"/login"
         assert handlers[0][1] == BricsLoginHandler
-        assert len(handlers[0][2]) == 4
+        assert len(handlers[0][2]) == 5
         assert handlers[0][2]["oidc_server"] == authenticator.oidc_server
         assert handlers[0][2]["platform"] == authenticator.brics_platform
         assert handlers[0][2]["jwt_audience"] == authenticator.jwt_audience
         assert handlers[0][2]["jwt_leeway"] == authenticator.jwt_leeway
+        assert handlers[0][2]["invalid_jwt_logout"] == authenticator.invalid_jwt_logout
 
         assert handlers[1][0] == r"/logout"
         assert handlers[1][1] == BricsLogoutHandler
@@ -64,10 +65,21 @@ class TestBricsLoginHandler:
             jwt_audience="dummy-audience",
             jwt_leeway=5,
             oidc_server="https://example.com",
+            invalid_jwt_logout=True,
         )
         handler_instance.http_client = AsyncMock()
         handler_instance.jwks_client_factory = MagicMock()
         return handler_instance
+
+
+    def test_logout_redirect(self, handler: BricsLoginHandler):
+        
+        with patch("bricsauthenticator.auth.BricsLoginHandler.redirect") as mock_redirect:
+            with pytest.raises(Finish):
+                handler._logout_redirect()
+
+            assert mock_redirect.mock_calls == [call("/logout")]
+
 
     def test_extract_token_missing_header(self, handler):
         handler.request.headers = HTTPHeaders({})
@@ -132,8 +144,26 @@ class TestBricsLoginHandler:
             assert result == decoded_token
             assert result == decoded_token
 
-    def test_decode_jwt_failure(self, handler):
+
+    def test_decode_jwt_failure_with_redirect(self, handler):
         handler.jwt_audience = "zenith-jupyter"
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "fake_key"
+
+        with (
+            patch("jwt.decode", side_effect=jwt.InvalidTokenError("Invalid token")),
+            patch("bricsauthenticator.auth.BricsLoginHandler.redirect") as mock_redirect
+        ):
+
+            with pytest.raises(Finish):
+                handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
+
+            assert mock_redirect.mock_calls == [call("/logout")]
+
+
+    def test_decode_jwt_failure_with_exception(self, handler):
+        handler.jwt_audience = "zenith-jupyter"
+        handler.invalid_jwt_logout = False
         mock_signing_key = MagicMock()
         mock_signing_key.key = "fake_key"
 
@@ -141,6 +171,7 @@ class TestBricsLoginHandler:
             with pytest.raises(HTTPError) as exc_info:
                 handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
             assert exc_info.value.status_code == 401
+
 
     def test_normalize_projects_invalid_json(self, handler):
         decoded_token = {"projects": "invalid_json"}
@@ -264,6 +295,7 @@ class TestBricsLoginHandler:
             oidc_server="https://example.com",
             jwt_audience="dummy-audience",
             jwt_leeway=5,
+            invalid_jwt_logout=True,
         )
 
         # Mock handler dependencies
@@ -308,34 +340,41 @@ class TestBricsLoginHandler:
         handler.set_login_cookie.assert_called_once_with(user)
         handler.redirect.assert_called_once_with("/home")
 
-    @pytest.mark.parametrize(
-        "platform, projects",
-        [
-            pytest.param("portal.example.notebooks.shared", {}, id="empty project claim"),
+
+    @pytest.fixture(params=[
+            pytest.param({
+                "platform": "portal.example.notebooks.shared", "projects": {}
+                }, 
+                id="empty project claim"
+            ),
             pytest.param(
-                "portal.example.other.shared",
                 {
-                    "project1": {
-                        "name": "Project 1",
-                        "resources": [
-                            {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
-                            {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
-                        ],
-                    },
-                    "project2": {
-                        "name": "Project 2",
-                        "resources": [
-                            {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}
-                        ],
-                    },
+                    "platform": "portal.example.other.shared",
+                    "projects": {
+                        "project1": {
+                            "name": "Project 1",
+                            "resources": [
+                                {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
+                                {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
+                            ],
+                        },
+                        "project2": {
+                            "name": "Project 2",
+                            "resources": [
+                                {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}
+                            ],
+                        },
+                    }
                 },
                 id="no projects with resource name matching platform",
             ),
-        ],
+        ]
     )
-    @pytest.mark.asyncio
-    async def test_get_no_valid_projects_exception(self, handler, platform: str, projects: dict[str, dict]):
-        handler.platform = platform
+    def no_valid_projects_handler(self, request: pytest.FixtureRequest, handler: BricsLoginHandler):
+        """
+        BricsLoginHandler with mocked _decode_jwt that returns a project claim with no valid projects
+        """
+        handler.platform = request.param["platform"]
 
         # Mock all methods up until a the token is decoded
         handler._extract_token = MagicMock()
@@ -349,16 +388,34 @@ class TestBricsLoginHandler:
             "iss": "https://example.com",
             "iat": 12344,
             "short_name": "user",
-            "projects": projects,
+            "projects": request.param["projects"],
         }
 
         # Mock the JWT decoding function and its return value
         handler._decode_jwt = MagicMock(return_value=decoded_token)
 
-        with pytest.raises(HTTPError, match="No projects with valid platform") as exc_info:
-            await handler.get()
+        return handler
 
+    
+    @pytest.mark.asyncio
+    async def test_get_no_valid_projects_redirect(self, no_valid_projects_handler: BricsLoginHandler):
+ 
+        with patch("bricsauthenticator.auth.BricsLoginHandler.redirect") as mock_redirect:
+            with pytest.raises(Finish):
+                await no_valid_projects_handler.get()
+
+            assert mock_redirect.mock_calls == [call("/logout")]
+
+
+    @pytest.mark.asyncio
+    async def test_get_no_valid_projects_exception(self, no_valid_projects_handler: BricsLoginHandler):
+        no_valid_projects_handler.invalid_jwt_logout = False
+ 
+        with pytest.raises(HTTPError, match="No projects with valid platform") as exc_info:
+            await no_valid_projects_handler.get()
+ 
         assert exc_info.value.status_code == 403
+
 
     @pytest.mark.parametrize(
         "decoded_token, expected_output",
@@ -462,6 +519,7 @@ class TestBricsLoginHandler:
         Check that JWTs with iat less than or equal to current time + leeway are valid
         """
 
+        handler.invalid_jwt_logout = False
         signing_key = MagicMock(spec=jwt.PyJWK)
         signing_key.key = "test-secret"
         algorithm = "HS256"
@@ -525,6 +583,7 @@ class TestBricsLoginHandler:
         Check that JWTs with exp greater than current time - leeway are valid
         """
 
+        handler.invalid_jwt_logout = False
         signing_key = MagicMock(spec=jwt.PyJWK)
         signing_key.key = "test-secret"
         algorithm = "HS256"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -368,12 +368,6 @@ class TestBricsLoginHandler:
         """
         handler.platform = request.param["platform"]
 
-        # Mock all methods up until a the token is decoded
-        handler._extract_token = MagicMock()
-        handler._fetch_oidc_config = AsyncMock()
-        handler._parse_oidc_config = MagicMock(return_value=(MagicMock, MagicMock))
-        handler._fetch_signing_key = MagicMock()
-
         decoded_token = {
             "aud": "zenith-jupyter",
             "exp": 12345,
@@ -391,6 +385,12 @@ class TestBricsLoginHandler:
     @pytest.mark.asyncio
     async def test_get_no_valid_projects_redirect(self, no_valid_projects_handler: BricsLoginHandler):
 
+        # Mock all methods up until the token is decoded
+        no_valid_projects_handler._extract_token = MagicMock()
+        no_valid_projects_handler._fetch_oidc_config = AsyncMock()
+        no_valid_projects_handler._parse_oidc_config = MagicMock(return_value=(MagicMock, MagicMock))
+        no_valid_projects_handler._fetch_signing_key = MagicMock()
+
         with patch("bricsauthenticator.auth.BricsLoginHandler.redirect") as mock_redirect:
             with pytest.raises(Finish):
                 await no_valid_projects_handler.get()
@@ -400,6 +400,12 @@ class TestBricsLoginHandler:
     @pytest.mark.asyncio
     async def test_get_no_valid_projects_exception(self, no_valid_projects_handler: BricsLoginHandler):
         no_valid_projects_handler.invalid_jwt_logout = False
+
+        # Mock all methods up until the token is decoded
+        no_valid_projects_handler._extract_token = MagicMock()
+        no_valid_projects_handler._fetch_oidc_config = AsyncMock()
+        no_valid_projects_handler._parse_oidc_config = MagicMock(return_value=(MagicMock, MagicMock))
+        no_valid_projects_handler._fetch_signing_key = MagicMock()
 
         with pytest.raises(HTTPError, match="No projects with valid platform") as exc_info:
             await no_valid_projects_handler.get()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -660,10 +660,7 @@ class TestBricsLogoutHandler:
         await handler.render_logout_page()
 
         # Check that `handler.redirect` is called with expected argument
-        mock_calls = handler.redirect.mock_calls
-        assert len(mock_calls) == 1
-        assert len(mock_calls[0].args) == 1
-        assert mock_calls[0].args[0] == handler.logout_redirect_url
+        assert handler.redirect.mock_calls == [call(handler.logout_redirect_url)]
 
 
     @pytest.mark.asyncio
@@ -678,10 +675,7 @@ class TestBricsLogoutHandler:
             await handler.render_logout_page()
 
             # Check that `super().render_logout_page` is called
-            mock_calls = mock_parent_render_logout_page.mock_calls
-            assert len(mock_calls) == 1
-            assert len(mock_calls[0].args) == 0
+            assert mock_parent_render_logout_page.mock_calls == [call()]
 
             # Check that `BricsLogoutHandler.redirect` is not called
-            mock_calls = mock_redirect
-            assert len(mock_calls) == 0
+            assert len(mock_redirect.mock_calls) == 0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,12 +3,12 @@ import json
 import time
 from contextlib import AbstractContextManager, nullcontext
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import jwt
 import pytest
 from tornado.httputil import HTTPHeaders, HTTPServerRequest
-from tornado.web import Application, HTTPError, Finish
+from tornado.web import Application, Finish, HTTPError
 
 from bricsauthenticator.auth import BricsAuthenticator, BricsLoginHandler, BricsLogoutHandler
 
@@ -71,15 +71,13 @@ class TestBricsLoginHandler:
         handler_instance.jwks_client_factory = MagicMock()
         return handler_instance
 
-
     def test_logout_redirect(self, handler: BricsLoginHandler):
-        
+
         with patch("bricsauthenticator.auth.BricsLoginHandler.redirect") as mock_redirect:
             with pytest.raises(Finish):
                 handler._logout_redirect()
 
             assert mock_redirect.mock_calls == [call("/logout")]
-
 
     def test_extract_token_missing_header(self, handler):
         handler.request.headers = HTTPHeaders({})
@@ -144,7 +142,6 @@ class TestBricsLoginHandler:
             assert result == decoded_token
             assert result == decoded_token
 
-
     def test_decode_jwt_failure_with_redirect(self, handler):
         handler.jwt_audience = "zenith-jupyter"
         mock_signing_key = MagicMock()
@@ -152,14 +149,13 @@ class TestBricsLoginHandler:
 
         with (
             patch("jwt.decode", side_effect=jwt.InvalidTokenError("Invalid token")),
-            patch("bricsauthenticator.auth.BricsLoginHandler.redirect") as mock_redirect
+            patch("bricsauthenticator.auth.BricsLoginHandler.redirect") as mock_redirect,
         ):
 
             with pytest.raises(Finish):
                 handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
 
             assert mock_redirect.mock_calls == [call("/logout")]
-
 
     def test_decode_jwt_failure_with_exception(self, handler):
         handler.jwt_audience = "zenith-jupyter"
@@ -171,7 +167,6 @@ class TestBricsLoginHandler:
             with pytest.raises(HTTPError) as exc_info:
                 handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
             assert exc_info.value.status_code == 401
-
 
     def test_normalize_projects_invalid_json(self, handler):
         decoded_token = {"projects": "invalid_json"}
@@ -340,13 +335,9 @@ class TestBricsLoginHandler:
         handler.set_login_cookie.assert_called_once_with(user)
         handler.redirect.assert_called_once_with("/home")
 
-
-    @pytest.fixture(params=[
-            pytest.param({
-                "platform": "portal.example.notebooks.shared", "projects": {}
-                }, 
-                id="empty project claim"
-            ),
+    @pytest.fixture(
+        params=[
+            pytest.param({"platform": "portal.example.notebooks.shared", "projects": {}}, id="empty project claim"),
             pytest.param(
                 {
                     "platform": "portal.example.other.shared",
@@ -364,7 +355,7 @@ class TestBricsLoginHandler:
                                 {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}
                             ],
                         },
-                    }
+                    },
                 },
                 id="no projects with resource name matching platform",
             ),
@@ -396,26 +387,23 @@ class TestBricsLoginHandler:
 
         return handler
 
-    
     @pytest.mark.asyncio
     async def test_get_no_valid_projects_redirect(self, no_valid_projects_handler: BricsLoginHandler):
- 
+
         with patch("bricsauthenticator.auth.BricsLoginHandler.redirect") as mock_redirect:
             with pytest.raises(Finish):
                 await no_valid_projects_handler.get()
 
             assert mock_redirect.mock_calls == [call("/logout")]
 
-
     @pytest.mark.asyncio
     async def test_get_no_valid_projects_exception(self, no_valid_projects_handler: BricsLoginHandler):
         no_valid_projects_handler.invalid_jwt_logout = False
- 
+
         with pytest.raises(HTTPError, match="No projects with valid platform") as exc_info:
             await no_valid_projects_handler.get()
- 
-        assert exc_info.value.status_code == 403
 
+        assert exc_info.value.status_code == 403
 
     @pytest.mark.parametrize(
         "decoded_token, expected_output",
@@ -662,7 +650,6 @@ class TestBricsLogoutHandler:
         # Check that `handler.redirect` is called with expected argument
         assert handler.redirect.mock_calls == [call(handler.logout_redirect_url)]
 
-
     @pytest.mark.asyncio
     async def test_render_logout_page_default(self, handler):
 
@@ -670,7 +657,7 @@ class TestBricsLogoutHandler:
 
         with (
             patch("bricsauthenticator.auth.LogoutHandler.render_logout_page") as mock_parent_render_logout_page,
-            patch("bricsauthenticator.auth.BricsLogoutHandler.redirect") as mock_redirect
+            patch("bricsauthenticator.auth.BricsLogoutHandler.redirect") as mock_redirect,
         ):
             await handler.render_logout_page()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,367 +10,387 @@ import pytest
 from tornado.httputil import HTTPHeaders, HTTPServerRequest
 from tornado.web import Application, HTTPError
 
-from bricsauthenticator.auth import BricsAuthenticator, BricsLoginHandler
+from bricsauthenticator.auth import BricsAuthenticator, BricsLoginHandler, BricsLogoutHandler
 
+class TestBricsAuthenticator:
 
-@pytest.fixture
-def handler():
-    # Create a real Application instance with necessary settings
-    application = Application()
-    application.settings = {
-        "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
-        "cookie_secret": b"secret",  # Add other required settings
-        "log_function": MagicMock(),  # Mock the application-level logger
-    }
+    def test_get_handlers(self):
+        # Create an instance of BricsAuthenticator
+        authenticator = BricsAuthenticator()
 
-    # Mock request with a connection attribute and empty headers
-    request = MagicMock(spec=HTTPServerRequest)
-    request.connection = MagicMock()  # Add the 'connection' attribute
-    request.headers = HTTPHeaders({})
+        # Mock the app object
+        app = MagicMock()
 
-    # Initialize BricsLoginHandler with the mocked application, request, and required arguments
-    handler_instance = BricsLoginHandler(
-        application,
-        request,
-        platform="portal.dummy.platform.shared",
-        jwt_audience="dummy-audience",
-        jwt_leeway=5,
-        oidc_server="https://example.com",
-    )
-    handler_instance.http_client = AsyncMock()
-    handler_instance.jwks_client_factory = MagicMock()
-    return handler_instance
+        # Call get_handlers and assert the result
+        handlers = authenticator.get_handlers(app)
+        assert len(handlers) == 2
+        assert handlers[0][0] == r"/login"
+        assert handlers[0][1] == BricsLoginHandler
+        assert len(handlers[0][2]) == 4
+        assert handlers[0][2]["oidc_server"] == authenticator.oidc_server
+        assert handlers[0][2]["platform"] == authenticator.brics_platform
+        assert handlers[0][2]["jwt_audience"] == authenticator.jwt_audience
+        assert handlers[0][2]["jwt_leeway"] == authenticator.jwt_leeway
 
+        assert handlers[1][0] == r"/logout"
+        assert handlers[1][1] == BricsLogoutHandler
+        assert len(handlers[1][2]) == 1
+        assert handlers[1][2]["logout_redirect_url"] == authenticator.logout_redirect_url
 
-def test_extract_token_missing_header(handler):
-    handler.request.headers = HTTPHeaders({})
-    with pytest.raises(HTTPError) as exc_info:
-        handler._extract_token()
-    assert exc_info.value.status_code == 401
-    assert "Missing X-Auth-Id-Token header" in str(exc_info.value)
+class TestBricsLoginHandler:
 
-
-def test_extract_token_success(handler):
-    handler.request.headers = HTTPHeaders({"X-Auth-Id-Token": "fake_token"})
-    token = handler._extract_token()
-    assert token == "fake_token"
-
-
-@pytest.mark.asyncio
-async def test_fetch_oidc_config_success(handler):
-    mock_response = AsyncMock()
-    mock_response.body = b'{"key": "value"}'
-    handler.http_client.fetch.return_value = mock_response
-
-    config = await handler._fetch_oidc_config()
-    assert config == {"key": "value"}
-
-
-@pytest.mark.asyncio
-async def test_fetch_oidc_config_failure(handler):
-    handler.http_client.fetch.side_effect = Exception("Fetch error")
-    with pytest.raises(HTTPError) as exc_info:
-        await handler._fetch_oidc_config()
-    assert exc_info.value.status_code == 500
-
-
-def test_parse_oidc_config(handler):
-    oidc_config = {"id_token_signing_alg_values_supported": ["RS256"], "jwks_uri": "https://example.com/jwks_uri"}
-    signing_algos, jwks_uri = handler._parse_oidc_config(oidc_config)
-    assert signing_algos == ["RS256"]
-    assert jwks_uri == "https://example.com/jwks_uri"
-
-
-def test_fetch_signing_key(handler):
-    mock_jwks_client = MagicMock()
-    handler.jwks_client_factory.return_value = mock_jwks_client
-    mock_signing_key = MagicMock()
-    mock_jwks_client.get_signing_key_from_jwt.return_value = mock_signing_key
-
-    signing_key = handler._fetch_signing_key("https://example.com/jwks_uri", "fake_token")
-    assert signing_key == mock_signing_key
-    handler.jwks_client_factory.assert_called_with("https://example.com/jwks_uri")
-    mock_jwks_client.get_signing_key_from_jwt.assert_called_with("fake_token")
-
-
-def test_decode_jwt_success(handler):
-    handler.jwt_audience = "zenith-jupyter"  # Match token's "aud" claim
-    decoded_token = {
-        "aud": "zenith-jupyter",  # Should match handler.jwt_audience
-        "exp": 12345,
-        "iss": "https://example.com",
-        "iat": 12344,
-        "short_name": "user",
-        "projects": {},
-    }
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "fake_key"
-
-    with patch("jwt.decode", return_value=decoded_token):
-        result = handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
-        assert result == decoded_token
-        assert result == decoded_token
-
-
-def test_decode_jwt_failure(handler):
-    handler.jwt_audience = "zenith-jupyter"
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "fake_key"
-
-    with patch("jwt.decode", side_effect=jwt.InvalidTokenError("Invalid token")):
-        with pytest.raises(HTTPError) as exc_info:
-            handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
-        assert exc_info.value.status_code == 401
-
-
-def test_normalize_projects_invalid_json(handler):
-    decoded_token = {"projects": "invalid_json"}
-    result = handler._normalize_projects(decoded_token)
-    assert result == {}  # Expect an empty dict instead of a raw string
-
-
-def test_normalize_projects_none(handler):
-    decoded_token = {}
-    result = handler._normalize_projects(decoded_token)
-    assert result == {}
-
-
-@pytest.mark.parametrize(
-    "platform,normalized_projects,expected_result",
-    [
-        pytest.param(
-            "portal.example.clusters.shared",
-            {
-                "project1.portal": {
-                    "name": "Project 1",
-                    "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
-                }
-            },
-            {},
-            id="1 project, 0 matching platform",
-        ),
-        pytest.param(
-            "portal.example.notebooks.shared",
-            {
-                "project1.portal": {
-                    "name": "Project 1",
-                    "resources": [
-                        {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
-                        {"name": "portal.example.other.shared", "username": "test_user.project1"},
-                    ],
-                }
-            },
-            {"project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"}},
-            id="1 project, 1 matching platform",
-        ),
-        pytest.param(
-            "portal.example.clusters.shared",
-            {
-                "project1.portal": {
-                    "name": "Project 1",
-                    "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
-                },
-                "project2.portal": {
-                    "name": "Project 2",
-                    "resources": [{"name": "portal.example.other.shared", "username": "test_user.project2"}],
-                },
-            },
-            {},
-            id="2 project, 0 matching platform",
-        ),
-        pytest.param(
-            "portal.example.notebooks.shared",
-            {
-                "project1.portal": {
-                    "name": "Project 1",
-                    "resources": [
-                        {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
-                        {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
-                    ],
-                },
-                "project2.portal": {
-                    "name": "Project 2",
-                    "resources": [{"name": "portal.example.other.shared", "username": "test_user.project2"}],
-                },
-            },
-            {"project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"}},
-            id="2 project, 1 matching platform",
-        ),
-        pytest.param(
-            "portal.example.notebooks.shared",
-            {
-                "project1.portal": {
-                    "name": "Project 1",
-                    "resources": [
-                        {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
-                        {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
-                    ],
-                },
-                "project2.portal": {
-                    "name": "Project 2",
-                    "resources": [
-                        {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}
-                    ],
-                },
-            },
-            {
-                "project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"},
-                "project2.portal": {"name": "Project 2", "username": "test_notebook_user.project2"},
-            },
-            id="2 project, 2 matching platform",
-        ),
-    ],
-)
-def test_auth_state_from_projects(handler, platform: str, normalized_projects: dict, expected_result: dict):
-    result = handler._auth_state_from_projects(projects=normalized_projects, platform=platform)
-    assert result == expected_result
-
-
-@pytest.mark.asyncio
-async def test_get():
-    # Create a real Application instance with necessary settings
-    application = Application()
-    application.settings = {
-        "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
-        "cookie_secret": b"secret",  # Add other required settings
-    }
-
-    # Mock request with a connection attribute
-    request = MagicMock(spec=HTTPServerRequest)
-    request.connection = MagicMock()  # Add the 'connection' attribute
-    request.headers = HTTPHeaders({"X-Auth-Id-Token": "fake_token"})
-
-    # Create an instance of the handler
-    handler = BricsLoginHandler(
-        application,
-        request,
-        platform="portal.cluster.example.shared",
-        oidc_server="https://example.com",
-        jwt_audience="dummy-audience",
-        jwt_leeway=5,
-    )
-
-    # Mock handler dependencies
-    handler._extract_token = MagicMock(return_value="mock_token")
-    handler._fetch_oidc_config = AsyncMock(
-        return_value={"id_token_signing_alg_values_supported": ["RS256"], "jwks_uri": "https://example.com/jwks"}
-    )
-    handler._parse_oidc_config = MagicMock(return_value=(["RS256"], "https://example.com/jwks"))
-    handler._fetch_signing_key = MagicMock(return_value=MagicMock(key="mock_key"))
-    projects = {
-        "project1": {
-            "name": "Project 1",
-            "resources": [{"name": "portal.cluster.example.shared", "username": "test_user.project1"}],
+    @pytest.fixture
+    def handler(self):
+        # Create a real Application instance with necessary settings
+        application = Application()
+        application.settings = {
+            "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
+            "cookie_secret": b"secret",  # Add other required settings
+            "log_function": MagicMock(),  # Mock the application-level logger
         }
-    }
-    decoded_token = {"short_name": "test_user", "projects": projects}
-    handler._decode_jwt = MagicMock(return_value=decoded_token)
-    handler._normalize_projects = MagicMock(return_value=projects)
-    auth_state = {"project1": {"name": "Project 1", "username": "test_user.project1"}}
-    handler._auth_state_from_projects = MagicMock(return_value=auth_state)
-    user = MagicMock()
-    user.name = "test_user"
-    handler.auth_to_user = AsyncMock(return_value=user)
-    handler.set_login_cookie = MagicMock()
-    handler.get_next_url = MagicMock(return_value="/home")
-    handler.redirect = MagicMock()
 
-    # Call the actual `get` method
-    await handler.get()
+        # Mock request with a connection attribute and empty headers
+        request = MagicMock(spec=HTTPServerRequest)
+        request.connection = MagicMock()  # Add the 'connection' attribute
+        request.headers = HTTPHeaders({})
 
-    # Assertions
-    handler._extract_token.assert_called_once()
-    handler._fetch_oidc_config.assert_called_once()
-    handler._parse_oidc_config.assert_called_once_with(
-        {"id_token_signing_alg_values_supported": ["RS256"], "jwks_uri": "https://example.com/jwks"}
+        # Initialize BricsLoginHandler with the mocked application, request, and required arguments
+        handler_instance = BricsLoginHandler(
+            application,
+            request,
+            platform="portal.dummy.platform.shared",
+            jwt_audience="dummy-audience",
+            jwt_leeway=5,
+            oidc_server="https://example.com",
+        )
+        handler_instance.http_client = AsyncMock()
+        handler_instance.jwks_client_factory = MagicMock()
+        return handler_instance
+
+
+    def test_extract_token_missing_header(self, handler):
+        handler.request.headers = HTTPHeaders({})
+        with pytest.raises(HTTPError) as exc_info:
+            handler._extract_token()
+        assert exc_info.value.status_code == 401
+        assert "Missing X-Auth-Id-Token header" in str(exc_info.value)
+    
+    
+    def test_extract_token_success(self, handler):
+        handler.request.headers = HTTPHeaders({"X-Auth-Id-Token": "fake_token"})
+        token = handler._extract_token()
+        assert token == "fake_token"
+    
+    
+    @pytest.mark.asyncio
+    async def test_fetch_oidc_config_success(self, handler):
+        mock_response = AsyncMock()
+        mock_response.body = b'{"key": "value"}'
+        handler.http_client.fetch.return_value = mock_response
+    
+        config = await handler._fetch_oidc_config()
+        assert config == {"key": "value"}
+    
+    
+    @pytest.mark.asyncio
+    async def test_fetch_oidc_config_failure(self, handler):
+        handler.http_client.fetch.side_effect = Exception("Fetch error")
+        with pytest.raises(HTTPError) as exc_info:
+            await handler._fetch_oidc_config()
+        assert exc_info.value.status_code == 500
+    
+    
+    def test_parse_oidc_config(self, handler):
+        oidc_config = {"id_token_signing_alg_values_supported": ["RS256"], "jwks_uri": "https://example.com/jwks_uri"}
+        signing_algos, jwks_uri = handler._parse_oidc_config(oidc_config)
+        assert signing_algos == ["RS256"]
+        assert jwks_uri == "https://example.com/jwks_uri"
+    
+    
+    def test_fetch_signing_key(self, handler):
+        mock_jwks_client = MagicMock()
+        handler.jwks_client_factory.return_value = mock_jwks_client
+        mock_signing_key = MagicMock()
+        mock_jwks_client.get_signing_key_from_jwt.return_value = mock_signing_key
+    
+        signing_key = handler._fetch_signing_key("https://example.com/jwks_uri", "fake_token")
+        assert signing_key == mock_signing_key
+        handler.jwks_client_factory.assert_called_with("https://example.com/jwks_uri")
+        mock_jwks_client.get_signing_key_from_jwt.assert_called_with("fake_token")
+    
+    
+    def test_decode_jwt_success(self, handler):
+        handler.jwt_audience = "zenith-jupyter"  # Match token's "aud" claim
+        decoded_token = {
+            "aud": "zenith-jupyter",  # Should match handler.jwt_audience
+            "exp": 12345,
+            "iss": "https://example.com",
+            "iat": 12344,
+            "short_name": "user",
+            "projects": {},
+        }
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "fake_key"
+    
+        with patch("jwt.decode", return_value=decoded_token):
+            result = handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
+            assert result == decoded_token
+            assert result == decoded_token
+    
+    
+    def test_decode_jwt_failure(self, handler):
+        handler.jwt_audience = "zenith-jupyter"
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "fake_key"
+    
+        with patch("jwt.decode", side_effect=jwt.InvalidTokenError("Invalid token")):
+            with pytest.raises(HTTPError) as exc_info:
+                handler._decode_jwt("fake_token", mock_signing_key, ["RS256"])
+            assert exc_info.value.status_code == 401
+    
+    
+    def test_normalize_projects_invalid_json(self, handler):
+        decoded_token = {"projects": "invalid_json"}
+        result = handler._normalize_projects(decoded_token)
+        assert result == {}  # Expect an empty dict instead of a raw string
+    
+    
+    def test_normalize_projects_none(self, handler):
+        decoded_token = {}
+        result = handler._normalize_projects(decoded_token)
+        assert result == {}
+    
+    
+    @pytest.mark.parametrize(
+        "platform,normalized_projects,expected_result",
+        [
+            pytest.param(
+                "portal.example.clusters.shared",
+                {
+                    "project1.portal": {
+                        "name": "Project 1",
+                        "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
+                    }
+                },
+                {},
+                id="1 project, 0 matching platform",
+            ),
+            pytest.param(
+                "portal.example.notebooks.shared",
+                {
+                    "project1.portal": {
+                        "name": "Project 1",
+                        "resources": [
+                            {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
+                            {"name": "portal.example.other.shared", "username": "test_user.project1"},
+                        ],
+                    }
+                },
+                {"project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"}},
+                id="1 project, 1 matching platform",
+            ),
+            pytest.param(
+                "portal.example.clusters.shared",
+                {
+                    "project1.portal": {
+                        "name": "Project 1",
+                        "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
+                    },
+                    "project2.portal": {
+                        "name": "Project 2",
+                        "resources": [{"name": "portal.example.other.shared", "username": "test_user.project2"}],
+                    },
+                },
+                {},
+                id="2 project, 0 matching platform",
+            ),
+            pytest.param(
+                "portal.example.notebooks.shared",
+                {
+                    "project1.portal": {
+                        "name": "Project 1",
+                        "resources": [
+                            {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
+                            {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
+                        ],
+                    },
+                    "project2.portal": {
+                        "name": "Project 2",
+                        "resources": [{"name": "portal.example.other.shared", "username": "test_user.project2"}],
+                    },
+                },
+                {"project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"}},
+                id="2 project, 1 matching platform",
+            ),
+            pytest.param(
+                "portal.example.notebooks.shared",
+                {
+                    "project1.portal": {
+                        "name": "Project 1",
+                        "resources": [
+                            {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
+                            {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
+                        ],
+                    },
+                    "project2.portal": {
+                        "name": "Project 2",
+                        "resources": [
+                            {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}
+                        ],
+                    },
+                },
+                {
+                    "project1.portal": {"name": "Project 1", "username": "test_notebook_user.project1"},
+                    "project2.portal": {"name": "Project 2", "username": "test_notebook_user.project2"},
+                },
+                id="2 project, 2 matching platform",
+            ),
+        ],
     )
-    handler._fetch_signing_key.assert_called_once_with("https://example.com/jwks", "mock_token")
-    handler._decode_jwt.assert_called_once_with("mock_token", handler._fetch_signing_key.return_value, ["RS256"])
-    handler._normalize_projects.assert_called_once_with(decoded_token)
-    handler._auth_state_from_projects.assert_called_once_with(projects, handler.platform)
-    handler.auth_to_user.assert_called_once_with({"name": "test_user", "auth_state": auth_state})
-    handler.set_login_cookie.assert_called_once_with(user)
-    handler.redirect.assert_called_once_with("/home")
-
-
-@pytest.mark.parametrize(
-    "platform, projects",
-    [
-        pytest.param("portal.example.notebooks.shared", {}, id="empty project claim"),
-        pytest.param(
-            "portal.example.other.shared",
-            {
-                "project1": {
-                    "name": "Project 1",
-                    "resources": [
-                        {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
-                        {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
-                    ],
-                },
-                "project2": {
-                    "name": "Project 2",
-                    "resources": [
-                        {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}
-                    ],
-                },
-            },
-            id="no projects with resource name matching platform",
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_get_no_valid_projects_exception(handler, platform: str, projects: dict[str, dict]):
-    handler.platform = platform
-
-    # Mock all methods up until a the token is decoded
-    handler._extract_token = MagicMock()
-    handler._fetch_oidc_config = AsyncMock()
-    handler._parse_oidc_config = MagicMock(return_value=(MagicMock, MagicMock))
-    handler._fetch_signing_key = MagicMock()
-
-    decoded_token = {
-        "aud": "zenith-jupyter",
-        "exp": 12345,
-        "iss": "https://example.com",
-        "iat": 12344,
-        "short_name": "user",
-        "projects": projects,
-    }
-
-    # Mock the JWT decoding function and its return value
-    handler._decode_jwt = MagicMock(return_value=decoded_token)
-
-    with pytest.raises(HTTPError, match="No projects with valid platform") as exc_info:
+    def test_auth_state_from_projects(self, handler, platform: str, normalized_projects: dict, expected_result: dict):
+        result = handler._auth_state_from_projects(projects=normalized_projects, platform=platform)
+        assert result == expected_result
+    
+    
+    @pytest.mark.asyncio
+    async def test_get(self):
+        # Create a real Application instance with necessary settings
+        application = Application()
+        application.settings = {
+            "hub": MagicMock(base_url="/hub/"),  # Mock 'hub' with base_url as a string
+            "cookie_secret": b"secret",  # Add other required settings
+        }
+    
+        # Mock request with a connection attribute
+        request = MagicMock(spec=HTTPServerRequest)
+        request.connection = MagicMock()  # Add the 'connection' attribute
+        request.headers = HTTPHeaders({"X-Auth-Id-Token": "fake_token"})
+    
+        # Create an instance of the handler
+        handler = BricsLoginHandler(
+            application,
+            request,
+            platform="portal.cluster.example.shared",
+            oidc_server="https://example.com",
+            jwt_audience="dummy-audience",
+            jwt_leeway=5,
+        )
+    
+        # Mock handler dependencies
+        handler._extract_token = MagicMock(return_value="mock_token")
+        handler._fetch_oidc_config = AsyncMock(
+            return_value={"id_token_signing_alg_values_supported": ["RS256"], "jwks_uri": "https://example.com/jwks"}
+        )
+        handler._parse_oidc_config = MagicMock(return_value=(["RS256"], "https://example.com/jwks"))
+        handler._fetch_signing_key = MagicMock(return_value=MagicMock(key="mock_key"))
+        projects = {
+            "project1": {
+                "name": "Project 1",
+                "resources": [{"name": "portal.cluster.example.shared", "username": "test_user.project1"}],
+            }
+        }
+        decoded_token = {"short_name": "test_user", "projects": projects}
+        handler._decode_jwt = MagicMock(return_value=decoded_token)
+        handler._normalize_projects = MagicMock(return_value=projects)
+        auth_state = {"project1": {"name": "Project 1", "username": "test_user.project1"}}
+        handler._auth_state_from_projects = MagicMock(return_value=auth_state)
+        user = MagicMock()
+        user.name = "test_user"
+        handler.auth_to_user = AsyncMock(return_value=user)
+        handler.set_login_cookie = MagicMock()
+        handler.get_next_url = MagicMock(return_value="/home")
+        handler.redirect = MagicMock()
+    
+        # Call the actual `get` method
         await handler.get()
-
-    assert exc_info.value.status_code == 403
-
-
-def test_get_handlers():
-    # Create an instance of BricsAuthenticator
-    authenticator = BricsAuthenticator()
-
-    # Mock the app object
-    app = MagicMock()
-
-    # Call get_handlers and assert the result
-    handlers = authenticator.get_handlers(app)
-    assert len(handlers) == 1
-    assert handlers[0][0] == r"/login"
-    assert handlers[0][1] == BricsLoginHandler
-    assert handlers[0][2]["oidc_server"] == authenticator.oidc_server
-    assert handlers[0][2]["platform"] == authenticator.brics_platform
-    assert handlers[0][2]["jwt_audience"] == authenticator.jwt_audience
-    assert handlers[0][2]["jwt_leeway"] == authenticator.jwt_leeway
-
-
-@pytest.mark.parametrize(
-    "decoded_token, expected_output",
-    [
-        # dict[str, dict] should be passed through unchanged
-        pytest.param(
-            {
-                "projects": {
+    
+        # Assertions
+        handler._extract_token.assert_called_once()
+        handler._fetch_oidc_config.assert_called_once()
+        handler._parse_oidc_config.assert_called_once_with(
+            {"id_token_signing_alg_values_supported": ["RS256"], "jwks_uri": "https://example.com/jwks"}
+        )
+        handler._fetch_signing_key.assert_called_once_with("https://example.com/jwks", "mock_token")
+        handler._decode_jwt.assert_called_once_with("mock_token", handler._fetch_signing_key.return_value, ["RS256"])
+        handler._normalize_projects.assert_called_once_with(decoded_token)
+        handler._auth_state_from_projects.assert_called_once_with(projects, handler.platform)
+        handler.auth_to_user.assert_called_once_with({"name": "test_user", "auth_state": auth_state})
+        handler.set_login_cookie.assert_called_once_with(user)
+        handler.redirect.assert_called_once_with("/home")
+    
+    
+    @pytest.mark.parametrize(
+        "platform, projects",
+        [
+            pytest.param("portal.example.notebooks.shared", {}, id="empty project claim"),
+            pytest.param(
+                "portal.example.other.shared",
+                {
+                    "project1": {
+                        "name": "Project 1",
+                        "resources": [
+                            {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project1"},
+                            {"name": "portal.example.clusters.shared", "username": "test_cluster_user.project1"},
+                        ],
+                    },
+                    "project2": {
+                        "name": "Project 2",
+                        "resources": [
+                            {"name": "portal.example.notebooks.shared", "username": "test_notebook_user.project2"}
+                        ],
+                    },
+                },
+                id="no projects with resource name matching platform",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_get_no_valid_projects_exception(self, handler, platform: str, projects: dict[str, dict]):
+        handler.platform = platform
+    
+        # Mock all methods up until a the token is decoded
+        handler._extract_token = MagicMock()
+        handler._fetch_oidc_config = AsyncMock()
+        handler._parse_oidc_config = MagicMock(return_value=(MagicMock, MagicMock))
+        handler._fetch_signing_key = MagicMock()
+    
+        decoded_token = {
+            "aud": "zenith-jupyter",
+            "exp": 12345,
+            "iss": "https://example.com",
+            "iat": 12344,
+            "short_name": "user",
+            "projects": projects,
+        }
+    
+        # Mock the JWT decoding function and its return value
+        handler._decode_jwt = MagicMock(return_value=decoded_token)
+    
+        with pytest.raises(HTTPError, match="No projects with valid platform") as exc_info:
+            await handler.get()
+    
+        assert exc_info.value.status_code == 403
+    
+    
+    
+    
+    @pytest.mark.parametrize(
+        "decoded_token, expected_output",
+        [
+            # dict[str, dict] should be passed through unchanged
+            pytest.param(
+                {
+                    "projects": {
+                        "brics.brics": {
+                            "name": "BriCS Technical Staff",
+                            "resources": [
+                                {"name": "brics.aip1.notebooks.shared", "username": "isambardfun.brics"},
+                                {"name": "brics.aip1.clusters.shared", "username": "isambardfun.brics"},
+                            ],
+                        }
+                    }
+                },
+                {
                     "brics.brics": {
                         "name": "BriCS Technical Staff",
                         "resources": [
@@ -378,195 +398,185 @@ def test_get_handlers():
                             {"name": "brics.aip1.clusters.shared", "username": "isambardfun.brics"},
                         ],
                     }
-                }
-            },
-            {
-                "brics.brics": {
-                    "name": "BriCS Technical Staff",
-                    "resources": [
-                        {"name": "brics.aip1.notebooks.shared", "username": "isambardfun.brics"},
-                        {"name": "brics.aip1.clusters.shared", "username": "isambardfun.brics"},
-                    ],
-                }
-            },
-            id="dict[str, dict] - unchanged",
-        ),
-        # dict[str, str] with JSON-encoded str should be decoded to dict[str, dict]
-        pytest.param(
-            {
-                "projects": json.dumps(
-                    {
-                        "benchmarking.portal": {
-                            "resources": [
-                                {"name": "benchmarking.aip1.notebooks", "username": "user1"},
-                                {"name": "benchmarking.i3.cluster", "username": "user2"},
-                            ]
+                },
+                id="dict[str, dict] - unchanged",
+            ),
+            # dict[str, str] with JSON-encoded str should be decoded to dict[str, dict]
+            pytest.param(
+                {
+                    "projects": json.dumps(
+                        {
+                            "benchmarking.portal": {
+                                "resources": [
+                                    {"name": "benchmarking.aip1.notebooks", "username": "user1"},
+                                    {"name": "benchmarking.i3.cluster", "username": "user2"},
+                                ]
+                            }
                         }
+                    )
+                },
+                {
+                    "benchmarking.portal": {
+                        "resources": [
+                            {"name": "benchmarking.aip1.notebooks", "username": "user1"},
+                            {"name": "benchmarking.i3.cluster", "username": "user2"},
+                        ]
                     }
-                )
-            },
-            {
-                "benchmarking.portal": {
-                    "resources": [
-                        {"name": "benchmarking.aip1.notebooks", "username": "user1"},
-                        {"name": "benchmarking.i3.cluster", "username": "user2"},
-                    ]
+                },
+                id="dict[str, str] JSON string - decode",
+            ),
+            # Invalid JSON should return an empty dict
+            pytest.param({"projects": "{invalid_json"}, {}, id="Invalid JSON - return empty"),
+            # Nested JSON string
+            pytest.param(
+                {"projects": json.dumps({"nested_project": {"resources": [{"name": "test.resource"}]}})},
+                {"nested_project": {"resources": [{"name": "test.resource"}]}},
+                id="Nested JSON string - decode",
+            ),
+            # Empty `projects` dict should return empty
+            pytest.param({"projects": {}}, {}, id="Empty projects - return empty"),
+            # Null `projects` value should return empty
+            pytest.param({"projects": None}, {}, id="Projects None - return empty"),
+            # JSON-encoded list (invalid case)
+            pytest.param({"projects": json.dumps([{"name": "test.resource"}])}, {}, id="JSON encoded list - invalid case"),
+        ],
+    )
+    def test_normalize_projects(self, handler, decoded_token, expected_output):
+        """
+        Test the _normalize_projects function to ensure it interprets
+        different input correctly
+        """
+        result = handler._normalize_projects(decoded_token)
+        assert result == expected_output
+    
+    
+    @pytest.mark.parametrize(
+        "leeway_seconds, delta_seconds, with_leeway_cm",
+        [
+            pytest.param(5, 1, nullcontext(), id="5s leeway, 2s delta"),
+            pytest.param(5, 3, nullcontext(), id="5s leeway, 3s delta"),
+            pytest.param(5, 5, nullcontext(), id="5s leeway, 5s delta"),
+            pytest.param(
+                5, 6, pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)"), id="5s leeway, 6s delta"
+            ),
+            pytest.param(3.5, 1, nullcontext(), id="3.5s leeway, 1s delta"),
+            pytest.param(
+                3.5, 4, pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)"), id="3.5s leeway, 4s delta"
+            ),
+        ],
+    )
+    def test_jwt_iat_validation_with_leeway(self, 
+        freezer, handler, leeway_seconds: int | float, delta_seconds: int, with_leeway_cm: AbstractContextManager
+    ):
+        """
+        Check that JWTs with iat less than or equal to current time + leeway are valid
+        """
+    
+        signing_key = MagicMock(spec=jwt.PyJWK)
+        signing_key.key = "test-secret"
+        algorithm = "HS256"
+    
+        # Freeze time to so that there is zero time between token setup and validation
+        # Set microsecond=0 to ensure that there are no rounding errors from using
+        # integer iat and exp claims
+        frozen_time = datetime.datetime.now().replace(microsecond=0)
+        freezer.move_to(frozen_time)
+    
+        # Simulate a token with delta seconds in the future
+        iat_adjusted = int(time.time() + delta_seconds)
+    
+        # ... that expires 5 minutes after it is issued
+        exp = int(iat_adjusted + timedelta(minutes=5).total_seconds())
+    
+        payload = {
+            "iat": iat_adjusted,
+            "exp": exp,
+            "aud": handler.jwt_audience,
+            "iss": handler.oidc_server,
+            "short_name": "testuser",
+            "projects": {
+                "project1.portal": {
+                    "name": "Project 1",
+                    "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
                 }
             },
-            id="dict[str, str] JSON string - decode",
-        ),
-        # Invalid JSON should return an empty dict
-        pytest.param({"projects": "{invalid_json"}, {}, id="Invalid JSON - return empty"),
-        # Nested JSON string
-        pytest.param(
-            {"projects": json.dumps({"nested_project": {"resources": [{"name": "test.resource"}]}})},
-            {"nested_project": {"resources": [{"name": "test.resource"}]}},
-            id="Nested JSON string - decode",
-        ),
-        # Empty `projects` dict should return empty
-        pytest.param({"projects": {}}, {}, id="Empty projects - return empty"),
-        # Null `projects` value should return empty
-        pytest.param({"projects": None}, {}, id="Projects None - return empty"),
-        # JSON-encoded list (invalid case)
-        pytest.param({"projects": json.dumps([{"name": "test.resource"}])}, {}, id="JSON encoded list - invalid case"),
-    ],
-)
-def test_normalize_projects(handler, decoded_token, expected_output):
-    """
-    Test the _normalize_projects function to ensure it interprets
-    different input correctly
-    """
-    result = handler._normalize_projects(decoded_token)
-    assert result == expected_output
-
-
-@pytest.mark.parametrize(
-    "leeway_seconds, delta_seconds, with_leeway_cm",
-    [
-        pytest.param(5, 1, nullcontext(), id="5s leeway, 2s delta"),
-        pytest.param(5, 3, nullcontext(), id="5s leeway, 3s delta"),
-        pytest.param(5, 5, nullcontext(), id="5s leeway, 5s delta"),
-        pytest.param(
-            5, 6, pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)"), id="5s leeway, 6s delta"
-        ),
-        pytest.param(3.5, 1, nullcontext(), id="3.5s leeway, 1s delta"),
-        pytest.param(
-            3.5, 4, pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)"), id="3.5s leeway, 4s delta"
-        ),
-    ],
-)
-def test_jwt_iat_validation_with_leeway(
-    freezer, handler, leeway_seconds: int | float, delta_seconds: int, with_leeway_cm: AbstractContextManager
-):
-    """
-    Check that JWTs with iat less than or equal to current time + leeway are valid
-    """
-
-    signing_key = MagicMock(spec=jwt.PyJWK)
-    signing_key.key = "test-secret"
-    algorithm = "HS256"
-
-    # Freeze time to so that there is zero time between token setup and validation
-    # Set microsecond=0 to ensure that there are no rounding errors from using
-    # integer iat and exp claims
-    frozen_time = datetime.datetime.now().replace(microsecond=0)
-    freezer.move_to(frozen_time)
-
-    # Simulate a token with delta seconds in the future
-    iat_adjusted = int(time.time() + delta_seconds)
-
-    # ... that expires 5 minutes after it is issued
-    exp = int(iat_adjusted + timedelta(minutes=5).total_seconds())
-
-    payload = {
-        "iat": iat_adjusted,
-        "exp": exp,
-        "aud": handler.jwt_audience,
-        "iss": handler.oidc_server,
-        "short_name": "testuser",
-        "projects": {
-            "project1.portal": {
-                "name": "Project 1",
-                "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
-            }
-        },
-    }
-
-    token = jwt.encode(payload, signing_key.key, algorithm=algorithm)
-
-    # Without leeway, this should fail
-    with pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)") as exc_info:
-        handler.jwt_leeway = 0
-        _ = handler._decode_jwt(token, signing_key, [algorithm])
-
-    assert exc_info.value.status_code == 401
-
-    # With leeway, it should succeed if not delta_seconds > leeway_seconds
-    with with_leeway_cm:
-        handler.jwt_leeway = leeway_seconds
-        decoded = handler._decode_jwt(token, signing_key, [algorithm])
-        assert decoded == payload
-
-
-@pytest.mark.parametrize(
-    "leeway_seconds, delta_seconds, with_leeway_cm",
-    [
-        pytest.param(5, 1, nullcontext(), id="5s leeway, 2s delta"),
-        pytest.param(5, 3, nullcontext(), id="5s leeway, 3s delta"),
-        pytest.param(5, 5, pytest.raises(HTTPError, match=r"Signature has expired"), id="5s leeway, 5s delta"),
-        pytest.param(5, 6, pytest.raises(HTTPError, match=r"Signature has expired"), id="5s leeway, 6s delta"),
-        pytest.param(3.5, 1, nullcontext(), id="3.5s leeway, 1s delta"),
-        pytest.param(3.5, 4, pytest.raises(HTTPError, match=r"Signature has expired"), id="3.5s leeway, 4s delta"),
-    ],
-)
-def test_jwt_exp_validation_with_leeway(
-    freezer, handler, leeway_seconds: int | float, delta_seconds: int, with_leeway_cm: AbstractContextManager
-):
-    """
-    Check that JWTs with exp greater than current time - leeway are valid
-    """
-
-    signing_key = MagicMock(spec=jwt.PyJWK)
-    signing_key.key = "test-secret"
-    algorithm = "HS256"
-
-    # Freeze time to so that there is zero time between token setup and validation
-    # Set microsecond=0 to ensure that there are no rounding errors from using
-    # integer iat and exp claims
-    frozen_time = datetime.datetime.now().replace(microsecond=0)
-    freezer.move_to(frozen_time)
-
-    # Simulate a token with iat 5 minutes + delta_seconds in the past
-    iat = int(time.time() - timedelta(minutes=5).total_seconds() - delta_seconds)
-
-    # ... that expires 5 minutes after it is issued and delta_seconds before now
-    exp = int(time.time() - delta_seconds)
-
-    payload = {
-        "iat": iat,
-        "exp": exp,
-        "aud": handler.jwt_audience,
-        "iss": handler.oidc_server,
-        "short_name": "testuser",
-        "projects": {
-            "project1.portal": {
-                "name": "Project 1",
-                "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
-            }
-        },
-    }
-
-    token = jwt.encode(payload, signing_key.key, algorithm=algorithm)
-
-    # Without leeway, this should fail
-    with pytest.raises(HTTPError, match=r"Signature has expired") as exc_info:
-        handler.jwt_leeway = 0
-        _ = handler._decode_jwt(token, signing_key, [algorithm])
-
-    assert exc_info.value.status_code == 401
-
-    # With leeway, it should succeed if not delta_seconds >= leeway_seconds
-    with with_leeway_cm:
-        handler.jwt_leeway = leeway_seconds
-        decoded = handler._decode_jwt(token, signing_key, [algorithm])
-        assert decoded == payload
+        }
+    
+        token = jwt.encode(payload, signing_key.key, algorithm=algorithm)
+    
+        # Without leeway, this should fail
+        with pytest.raises(HTTPError, match=r"The token is not yet valid \(iat\)") as exc_info:
+            handler.jwt_leeway = 0
+            _ = handler._decode_jwt(token, signing_key, [algorithm])
+    
+        assert exc_info.value.status_code == 401
+    
+        # With leeway, it should succeed if not delta_seconds > leeway_seconds
+        with with_leeway_cm:
+            handler.jwt_leeway = leeway_seconds
+            decoded = handler._decode_jwt(token, signing_key, [algorithm])
+            assert decoded == payload
+    
+    
+    @pytest.mark.parametrize(
+        "leeway_seconds, delta_seconds, with_leeway_cm",
+        [
+            pytest.param(5, 1, nullcontext(), id="5s leeway, 2s delta"),
+            pytest.param(5, 3, nullcontext(), id="5s leeway, 3s delta"),
+            pytest.param(5, 5, pytest.raises(HTTPError, match=r"Signature has expired"), id="5s leeway, 5s delta"),
+            pytest.param(5, 6, pytest.raises(HTTPError, match=r"Signature has expired"), id="5s leeway, 6s delta"),
+            pytest.param(3.5, 1, nullcontext(), id="3.5s leeway, 1s delta"),
+            pytest.param(3.5, 4, pytest.raises(HTTPError, match=r"Signature has expired"), id="3.5s leeway, 4s delta"),
+        ],
+    )
+    def test_jwt_exp_validation_with_leeway(self, 
+        freezer, handler, leeway_seconds: int | float, delta_seconds: int, with_leeway_cm: AbstractContextManager
+    ):
+        """
+        Check that JWTs with exp greater than current time - leeway are valid
+        """
+    
+        signing_key = MagicMock(spec=jwt.PyJWK)
+        signing_key.key = "test-secret"
+        algorithm = "HS256"
+    
+        # Freeze time to so that there is zero time between token setup and validation
+        # Set microsecond=0 to ensure that there are no rounding errors from using
+        # integer iat and exp claims
+        frozen_time = datetime.datetime.now().replace(microsecond=0)
+        freezer.move_to(frozen_time)
+    
+        # Simulate a token with iat 5 minutes + delta_seconds in the past
+        iat = int(time.time() - timedelta(minutes=5).total_seconds() - delta_seconds)
+    
+        # ... that expires 5 minutes after it is issued and delta_seconds before now
+        exp = int(time.time() - delta_seconds)
+    
+        payload = {
+            "iat": iat,
+            "exp": exp,
+            "aud": handler.jwt_audience,
+            "iss": handler.oidc_server,
+            "short_name": "testuser",
+            "projects": {
+                "project1.portal": {
+                    "name": "Project 1",
+                    "resources": [{"name": "portal.example.other.shared", "username": "test_user.project1"}],
+                }
+            },
+        }
+    
+        token = jwt.encode(payload, signing_key.key, algorithm=algorithm)
+    
+        # Without leeway, this should fail
+        with pytest.raises(HTTPError, match=r"Signature has expired") as exc_info:
+            handler.jwt_leeway = 0
+            _ = handler._decode_jwt(token, signing_key, [algorithm])
+    
+        assert exc_info.value.status_code == 401
+    
+        # With leeway, it should succeed if not delta_seconds >= leeway_seconds
+        with with_leeway_cm:
+            handler.jwt_leeway = leeway_seconds
+            decoded = handler._decode_jwt(token, signing_key, [algorithm])
+            assert decoded == payload


### PR DESCRIPTION
* Add a custom logout request handler `BricsLogoutHandler` 
  * Extends `LogoutHandler.render_logout_page()` to redirect to a custom URL (set by the `BricsAuthenticator.logout_redirect_url` traitlet) after JupyterHub has completed its logout procedure
  * This can be used to redirect to an external URL endpoint to perform additional logout steps (e.g. clearing OAuth2 Proxy's session storage cookies by going to the [`sign_out` endpoint](https://oauth2-proxy.github.io/oauth2-proxy/features/endpoints))
* Modify `BricsLoginHandler` to enable optional automatic redirection to JupyterHub's logout URL when an invalid JWT is encountered
  * Enabled by setting the `BricsAuthenticator.invalid_jwt_logout` traitlet to `True`
  * This can be used in combination with `BricsAuthenticator.logout_redirect_url` to redirect to an external URL that clears external authentication state and refreshes the JWT
* Update unit tests 
  * Encapsulate existing `BricsAuthenticator` and `BricsLoginHandler` tests in classes
  * Add new tests for `BricsLogoutHandler`
  * Update existing `BricsAuthenticator` and `BricsLoginHandler` tests to support automatic-redirect functionality
  * New `BricsLoginHandler` tests for automatic-redirect functionality
* Removes Codecov integration
  * Remove `codecov/codecov-action` GitHub Actions workflow step
  * Remove `codecov.yml`
  * Remove Codecov badge from `README.md`
 
Codecov removal was included because this repo was using an outdated GitHub Action `codecov/codecov-action` and had no upload token set. According to the Codecov documentation, installing the Codecov GitHub App for the organisation is required for Codecov to work correctly.

We can continue to access coverage information from the terminal output for the `pytest` coverage step in the GitHub Actions workflow and the associated artifacts attached to each Actions run.