### PR TITLE
Add BriCS admins to brics-admins group

### DIFF
--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -57,26 +57,33 @@ class BricsLoginHandler(BaseHandler):
 
         self.log.debug("Decoded JWT Token:\n" + "\n".join(f"{key}: {value}" for key, value in decoded_token.items()))
 
-        projects = self._normalize_projects(decoded_token)
+        # If the user is an admin
+        if (groups := decoded_token.get("groups")) and "/BriCSAdmins" in groups:
+            username = decoded_token.get("preferred_username")
+            auth_state = {}
+            groups = ["brics-admins"]
+        else:
+            projects = self._normalize_projects(decoded_token)
 
-        username = decoded_token.get("short_name")
-        if not username:
-            if self.invalid_jwt_logout:
-                self.log.info("Invalid token: Missing short_name claim")
-                self._logout_redirect()
-            else:
-                raise web.HTTPError(401, "Invalid token: Missing short_name claim")
+            username = decoded_token.get("short_name")
+            if not username:
+                if self.invalid_jwt_logout:
+                    self.log.info("Invalid token: Missing short_name claim")
+                    self._logout_redirect()
+                else:
+                    raise web.HTTPError(401, "Invalid token: Missing short_name claim")
 
-        auth_state = self._auth_state_from_projects(projects, self.platform)
+            auth_state = self._auth_state_from_projects(projects, self.platform)
+            groups = []
 
-        if not len(auth_state) > 0:
-            if self.invalid_jwt_logout:
-                self.log.info("No projects with valid platform")
-                self._logout_redirect()
-            else:
-                raise web.HTTPError(403, "No projects with valid platform")
+            if not len(auth_state) > 0:
+                if self.invalid_jwt_logout:
+                    self.log.info("No projects with valid platform")
+                    self._logout_redirect()
+                else:
+                    raise web.HTTPError(403, "No projects with valid platform")
 
-        user = await self.auth_to_user({"name": username, "auth_state": auth_state})
+        user = await self.auth_to_user({"name": username, "auth_state": auth_state, "groups": groups})
         self.set_login_cookie(user)
         next_url = self.get_next_url(user)
         self.redirect(next_url)
@@ -115,7 +122,7 @@ class BricsLoginHandler(BaseHandler):
                 algorithms=signing_algos,
                 options={
                     "verify_signature": True,
-                    "require": ["aud", "exp", "iss", "iat", "short_name", "projects"],
+                    "require": ["aud", "exp", "iss", "iat"],
                 },
                 audience=self.jwt_audience,  # make it configurable
                 issuer=self.oidc_server,

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -41,8 +41,43 @@ class BricsLoginHandler(BaseHandler):
         self.redirect(self.settings["logout_url"])
         raise web.Finish
 
-    async def get(self):
+    def _token_to_user(self, token) -> dict:
+        """
+        Take a decoded JWT token and convert it into an authenticated user description
+        """
+        # If the user is an admin
+        groups = []
+        if "/BriCSAdmins" in token.get("groups", []):
+            groups.append("brics-admins")
 
+        projects = self._normalize_projects(token)
+
+        auth_state = self._auth_state_from_projects(projects, self.platform)
+
+        # Only admins can have an empty filtered project dict (auth_state)
+        if not (auth_state or "brics-admins" in groups):
+            if self.invalid_jwt_logout:
+                self.log.info("No projects with valid platform")
+                self._logout_redirect()
+            else:
+                raise web.HTTPError(403, "No projects with valid platform")
+
+        username = token.get("short_name")
+        if not username and "brics-admins" in groups:
+            # Fall back to preferred_username if short_name not present,
+            # but only for admins
+            username = token.get("preferred_username")
+
+        if not username:
+            if self.invalid_jwt_logout:
+                self.log.info("Invalid token: Missing username claim (short_name or preferred_username")
+                self._logout_redirect()
+            else:
+                raise web.HTTPError(401, "Invalid token: Missing short_name claim")
+
+        return {"name": username, "auth_state": auth_state, "groups": groups}
+
+    async def get(self):
         self.log.debug(
             "Estimated request header size: %d bytes",
             sum(len((name + ":" + value).encode("ascii")) for name, value in self.request.headers.get_all()),
@@ -57,33 +92,9 @@ class BricsLoginHandler(BaseHandler):
 
         self.log.debug("Decoded JWT Token:\n" + "\n".join(f"{key}: {value}" for key, value in decoded_token.items()))
 
-        # If the user is an admin
-        if (groups := decoded_token.get("groups")) and "/BriCSAdmins" in groups:
-            username = decoded_token.get("preferred_username")
-            auth_state = {}
-            groups = ["brics-admins"]
-        else:
-            projects = self._normalize_projects(decoded_token)
+        user_model = self._token_to_user(decoded_token)
 
-            username = decoded_token.get("short_name")
-            if not username:
-                if self.invalid_jwt_logout:
-                    self.log.info("Invalid token: Missing short_name claim")
-                    self._logout_redirect()
-                else:
-                    raise web.HTTPError(401, "Invalid token: Missing short_name claim")
-
-            auth_state = self._auth_state_from_projects(projects, self.platform)
-            groups = []
-
-            if not len(auth_state) > 0:
-                if self.invalid_jwt_logout:
-                    self.log.info("No projects with valid platform")
-                    self._logout_redirect()
-                else:
-                    raise web.HTTPError(403, "No projects with valid platform")
-
-        user = await self.auth_to_user({"name": username, "auth_state": auth_state, "groups": groups})
+        user = await self.auth_to_user(user_model)
         self.set_login_cookie(user)
         next_url = self.get_next_url(user)
         self.redirect(next_url)

--- a/src/bricsauthenticator/auth.py
+++ b/src/bricsauthenticator/auth.py
@@ -21,6 +21,8 @@ class BricsLoginHandler(BaseHandler):
         jwt_audience: str,
         jwt_leeway: float,
         invalid_jwt_logout: bool,
+        admin_group_claim: str,
+        admin_group_name: str,
         http_client=None,
         jwks_client_factory=None,
     ):
@@ -29,6 +31,8 @@ class BricsLoginHandler(BaseHandler):
         self.jwt_audience = jwt_audience
         self.jwt_leeway = jwt_leeway
         self.invalid_jwt_logout = invalid_jwt_logout
+        self.admin_group_claim = admin_group_claim
+        self.admin_group_name = admin_group_name
         self.http_client = http_client or AsyncHTTPClient()
         self.jwks_client_factory = jwks_client_factory or self._default_jwks_client_factory
 
@@ -47,15 +51,15 @@ class BricsLoginHandler(BaseHandler):
         """
         # If the user is an admin
         groups = []
-        if "/BriCSAdmins" in token.get("groups", []):
-            groups.append("brics-admins")
+        if self.admin_group_claim in token.get("groups", []):
+            groups.append(self.admin_group_name)
 
         projects = self._normalize_projects(token)
 
         auth_state = self._auth_state_from_projects(projects, self.platform)
 
         # Only admins can have an empty filtered project dict (auth_state)
-        if not (auth_state or "brics-admins" in groups):
+        if not (auth_state or self.admin_group_name in groups):
             if self.invalid_jwt_logout:
                 self.log.info("No projects with valid platform")
                 self._logout_redirect()
@@ -63,7 +67,7 @@ class BricsLoginHandler(BaseHandler):
                 raise web.HTTPError(403, "No projects with valid platform")
 
         username = token.get("short_name")
-        if not username and "brics-admins" in groups:
+        if not username and self.admin_group_name in groups:
             # Fall back to preferred_username if short_name not present,
             # but only for admins
             username = token.get("preferred_username")
@@ -280,6 +284,18 @@ class BricsAuthenticator(Authenticator):
         allow_none=False,
     ).tag(config=True)
 
+    admin_group_claim = Unicode(
+        default_value="/BriCSAdmins",
+        help="The name of the group in the groups claim to map to admin users",
+        allow_none=False,
+    ).tag(config=True)
+
+    admin_group_name = Unicode(
+        default_value="brics-admins",
+        help="The name of the JupyterHub group to put admins in",
+        allow_none=False,
+    ).tag(config=True)
+
     def get_handlers(self, app):
         return [
             (
@@ -291,6 +307,8 @@ class BricsAuthenticator(Authenticator):
                     "jwt_audience": self.jwt_audience,
                     "jwt_leeway": self.jwt_leeway,
                     "invalid_jwt_logout": self.invalid_jwt_logout,
+                    "admin_group_claim": self.admin_group_claim,
+                    "admin_group_name": self.admin_group_name,
                 },
             ),
             (r"/logout", BricsLogoutHandler, {"logout_redirect_url": self.logout_redirect_url}),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -332,7 +332,7 @@ class TestBricsLoginHandler:
         handler._decode_jwt.assert_called_once_with("mock_token", handler._fetch_signing_key.return_value, ["RS256"])
         handler._normalize_projects.assert_called_once_with(decoded_token)
         handler._auth_state_from_projects.assert_called_once_with(projects, handler.platform)
-        handler.auth_to_user.assert_called_once_with({"name": "test_user", "auth_state": auth_state})
+        handler.auth_to_user.assert_called_once_with({"name": "test_user", "auth_state": auth_state, "groups": []})
         handler.set_login_cookie.assert_called_once_with(user)
         handler.redirect.assert_called_once_with("/home")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,7 @@ class TestBricsAuthenticator:
         assert len(handlers) == 2
         assert handlers[0][0] == r"/login"
         assert handlers[0][1] == BricsLoginHandler
-        assert len(handlers[0][2]) == 5
+        assert len(handlers[0][2]) == 7
         assert handlers[0][2]["oidc_server"] == authenticator.oidc_server
         assert handlers[0][2]["platform"] == authenticator.brics_platform
         assert handlers[0][2]["jwt_audience"] == authenticator.jwt_audience
@@ -67,6 +67,8 @@ class TestBricsLoginHandler:
             jwt_leeway=5,
             oidc_server="https://example.com",
             invalid_jwt_logout=True,
+            admin_group_claim="/BriCSAdmins",
+            admin_group_name="brics-admins",
         )
         handler_instance.http_client = AsyncMock()
         handler_instance.jwks_client_factory = MagicMock()
@@ -322,6 +324,8 @@ class TestBricsLoginHandler:
             jwt_audience="dummy-audience",
             jwt_leeway=5,
             invalid_jwt_logout=True,
+            admin_group_claim="/BriCSAdmins",
+            admin_group_name="brics-admins",
         )
 
         # Mock handler dependencies

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -269,6 +269,36 @@ class TestBricsLoginHandler:
         result = handler._auth_state_from_projects(projects=normalized_projects, platform=platform)
         assert result == expected_result
 
+    @pytest.mark.parametrize(
+        "token,expected_user",
+        [
+            pytest.param(
+                {
+                    "projects": {
+                        "p1": {
+                            "name": "P1",
+                            "resources": [{"name": "portal.dummy.platform.shared", "username": "test_user.p1"}],
+                        }
+                    },
+                    "short_name": "test_user",
+                },
+                {"name": "test_user", "auth_state": {"p1": {"name": "P1", "username": "test_user.p1"}}, "groups": []},
+                id="normal user on project",
+            ),
+            pytest.param(
+                {
+                    "preferred_username": "test-admin",
+                    "groups": ["/BriCSAdmins"],
+                },
+                {"name": "test-admin", "auth_state": {}, "groups": ["brics-admins"]},
+                id="admin user",
+            ),
+        ],
+    )
+    def test_token_to_user(self, handler, token: dict, expected_user: dict):
+        user = handler._token_to_user(token)
+        assert user == expected_user
+
     @pytest.mark.asyncio
     async def test_get(self):
         # Create a real Application instance with necessary settings


### PR DESCRIPTION
This adds any user who is logging in with the `/BriCSAdmin` group in their JWT to a `brics-admins` group. This can be then used to assign relevant roles in the JupyterHub config.

The admins are not given any project assignments (they don't have any anyway) and so cannot spawn servers for themselves.

See isambard-sc/brics_jupyterhub_envs#42