### PR TITLE
Move to use PEP 735 dependency groups

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
       "requireLocalPort": true
     }
   },
-  "postCreateCommand": "python3 -m pip install --no-cache-dir --root-user-action=ignore --editable --group dev '${containerWorkspaceFolder}'",
+  "postCreateCommand": "python3 -m pip install --no-cache-dir --root-user-action=ignore --group dev --editable '${containerWorkspaceFolder}'",
   
   // Disable labelling to avoid access issues with bind-mounting workspace folder for hosts using SELinux
   "securityOpt": ["label=disable"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
       "requireLocalPort": true
     }
   },
-  "postCreateCommand": "python3 -m pip install --no-cache-dir --root-user-action=ignore --editable '${containerWorkspaceFolder}[dev]'",
+  "postCreateCommand": "python3 -m pip install --no-cache-dir --root-user-action=ignore --editable --group dev '${containerWorkspaceFolder}'",
   
   // Disable labelling to avoid access issues with bind-mounting workspace folder for hosts using SELinux
   "securityOpt": ["label=disable"]

--- a/.github/workflows/build_lint_test.yml
+++ b/.github/workflows/build_lint_test.yml
@@ -13,13 +13,13 @@ jobs:
   build_lint_test:
 
     env:
-      PYTHON_VERSION_COVERAGE_UPLOAD: "3.12"
+      PYTHON_VERSION_COVERAGE_UPLOAD: "3.14"
 
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     
     permissions:
       contents: read
@@ -43,7 +43,7 @@ jobs:
     - name: Install package and tooling 
       id: install
       run: |
-        python -m pip install "${GITHUB_WORKSPACE}[dev]"
+        python -m pip install --group dev "${GITHUB_WORKSPACE}"
 
     - name: Lint
       if: ${{ always() && steps.install.conclusion == 'success' }}

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ Install from the sdist or wheel placed in the `dist/` directory
 
 ### Install with development dependencies
 
-Use the `[dev]` optional dependency to install development tools (linting, formatting, testing etc.) alongside the `bricsauthenticator` package.
+Use the `dev` optional dependency group to install development tools (linting, formatting, testing etc.) alongside the `bricsauthenticator` package.
 
 This is useful in combination with an editable install from a local copy of the repository. The local copy can then be worked with using the development tools.
 
 ```shell
-/path/to/my-venv/bin/python -m pip install -e '/path/to/bricsauthenticator[dev]'
+/path/to/my-venv/bin/python -m pip install -e --group dev '/path/to/bricsauthenticator'
 ```
 
 ### Development install in a Conda environment

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Use the `dev` optional dependency group to install development tools (linting, f
 This is useful in combination with an editable install from a local copy of the repository. The local copy can then be worked with using the development tools.
 
 ```shell
-/path/to/my-venv/bin/python -m pip install -e --group dev '/path/to/bricsauthenticator'
+/path/to/my-venv/bin/python -m pip install --group dev -e '/path/to/bricsauthenticator'
 ```
 
 ### Development install in a Conda environment

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,4 +13,4 @@ dependencies:
 
   - pip
   - pip:
-    - --editable --group dev .
+    - --group dev --editable .

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,4 +13,4 @@ dependencies:
 
   - pip
   - pip:
-    - --editable '.[dev]'
+    - --editable --group dev .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ dependencies = [
     "batchspawner >= 1.3.0"
 ]
 
-[project.optional-dependencies]
-# Install development dependencies using the [dev] variant, e.g. for local
+[dependency-groups]
+# Install development dependencies using the dev group, e.g. for local
 # editable install from current directory:
-#   python -m pip install -e ".[dev]"
+#   python -m pip install -e --group dev .
 dev = [
     "pytest",
     "pytest-asyncio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 [dependency-groups]
 # Install development dependencies using the dev group, e.g. for local
 # editable install from current directory:
-#   python -m pip install -e --group dev .
+#   python -m pip install --group dev -e .
 dev = [
     "pytest",
     "pytest-asyncio",


### PR DESCRIPTION
This allows using PEP-compliant tooling like `uv` to do:

```console
$ uv run pytest
```